### PR TITLE
config: follow XDG base spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ sudo superfreq set-max-freq 2800 --core-id 1
 
 Superfreq uses TOML configuration files. Default locations:
 
-- `/etc/superfreq/config.toml`
+- `/etc/xdg/superfreq/config.toml`
 - `/etc/superfreq.toml`
 
 You can also specify a custom path by setting the `SUPERFREQ_CONFIG` environment

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -46,7 +46,7 @@ pub fn load_config_from_path(specific_path: Option<&str>) -> Result<AppConfig, C
     }
 
     // System-wide paths
-    config_paths.push(PathBuf::from("/etc/superfreq/config.toml"));
+    config_paths.push(PathBuf::from("/etc/xdg/superfreq/config.toml"));
     config_paths.push(PathBuf::from("/etc/superfreq.toml"));
 
     for path in config_paths {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -274,7 +274,7 @@ const GOVERNOR_OVERRIDE_PATH: &str = "/etc/superfreq/governor_override";
 /// Force a specific CPU governor or reset to automatic mode
 pub fn force_governor(mode: GovernorOverrideMode) -> Result<()> {
     // Create directory if it doesn't exist
-    let dir_path = Path::new("/etc/superfreq");
+    let dir_path = Path::new("/etc/xdg/superfreq");
     if !dir_path.exists() {
         fs::create_dir_all(dir_path).map_err(|e| {
             if e.kind() == io::ErrorKind::PermissionDenied {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -65,7 +65,7 @@ pub fn run_daemon(mut config: AppConfig, verbose: bool) -> Result<(), Box<dyn st
         Some(path)
     } else {
         // Check standard config paths
-        let default_paths = ["/etc/superfreq/config.toml", "/etc/superfreq.toml"];
+        let default_paths = ["/etc/xdg/superfreq/config.toml", "/etc/superfreq.toml"];
 
         default_paths
             .iter()


### PR DESCRIPTION
moves /etc/superfreq/config.toml to /etc/xdg/superfreq/config.toml to follow xdg base spec more closely.