### PR TITLE
feature: dynamic CPU turbo management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "superfreq"
+description = "Modern CPU frequency and power management utility for Linux"
 version = "0.2.0"
 edition = "2024"
+authors = ["NotAShelf <raf@notashelf.dev>"]
+rust-version = "1.85"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ but most common usecases are already implemented.
   and turbo boost
 - **Intelligent Power Management**: Different profiles for AC and battery
   operation
+- **Dynamic Turbo Boost Control**: Automatically enables/disables turbo based on
+  CPU load and temperature
 - **Fine-tuned Controls**: Adjust energy performance preferences, biases, and
   frequency limits
 - **Per-core Control**: Apply settings globally or to specific CPU cores
@@ -150,6 +152,10 @@ variable.
 governor = "performance"
 # Turbo boost setting: "always", "auto", or "never"
 turbo = "auto"
+# Enable or disable automatic turbo management (when turbo = "auto")
+enable_auto_turbo = true
+# Custom thresholds for auto turbo management
+turbo_auto_settings = { load_threshold_high = 70.0, load_threshold_low = 30.0, temp_threshold_high = 75.0 }
 # Energy Performance Preference
 epp = "performance"
 # Energy Performance Bias (0-15 scale or named value)
@@ -166,6 +172,9 @@ max_freq_mhz = 3500
 [battery]
 governor = "powersave"
 turbo = "auto"
+# More conservative auto turbo settings on battery
+enable_auto_turbo = true
+turbo_auto_settings = { load_threshold_high = 80.0, load_threshold_low = 40.0, temp_threshold_high = 70.0 }
 epp = "power"
 epb = "balance_power"
 platform_profile = "low-power"
@@ -208,6 +217,27 @@ mouse_battery = "hid-12:34:56:78:90:ab-battery"
 Those are the more advanced features of Superfreq that some users might be more
 inclined to use than others. If you have a use-case that is not covered, please
 create an issue.
+
+### Dynamic Turbo Boost Management
+
+When using `turbo = "auto"` with `enable_auto_turbo = true`, Superfreq
+dynamically controls CPU turbo boost based on:
+
+- **CPU Load Thresholds**: Enables turbo when load exceeds `load_threshold_high`
+  (default 70%), disables when below `load_threshold_low` (default 30%)
+- **Temperature Protection**: Automatically disables turbo when CPU temperature
+  exceeds `temp_threshold_high` (default 75°C)
+- **Hysteresis Control**: Prevents rapid toggling by maintaining previous state
+  when load is between thresholds
+- **Profile-Specific Settings**: Configure different thresholds for battery vs.
+  AC power
+
+This feature optimizes performance and power consumption by providing maximum
+performance for demanding tasks while conserving energy during light workloads.
+
+> [!TIP]
+> You can disable this logic with `enable_auto_turbo = false` to let the system
+> handle turbo boost natively when `turbo = "auto"`.
 
 ### Adaptive Polling
 
@@ -275,7 +305,8 @@ the codebase as they stand.
 
 ### Setup
 
-You will need Cargo and Rust installed on your system. Rust 1.80 or later is required.
+You will need Cargo and Rust installed on your system. Rust 1.80 or later is
+required.
 
 A `.envrc` is provided, and it's usage is encouraged for Nix users.
 Alternatively, you may use Nix for a reproducible developer environment

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ the codebase as they stand.
 
 ### Setup
 
-You will need Cargo and Rust installed on your system. Rust 1.80 or later is
+You will need Cargo and Rust installed on your system. Rust 1.85 or later is
 required.
 
 A `.envrc` is provided, and it's usage is encouraged for Nix users.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Superfreq is a modern CPU frequency and power management utility for Linux
 systems. It provides intelligent control of CPU governors, frequencies, and
 power-saving features, helping optimize both performance and battery life.
 
-It is greatly inspired by auto_cpufreq, but rewritten from ground up to provide
+It is greatly inspired by auto-cpufreq, but rewritten from ground up to provide
 a smoother experience with a more efficient and more correct codebase. Some
-features are omitted, and it is _not_ a drop-in replacement for auto_cpufreq,
+features are omitted, and it is _not_ a drop-in replacement for auto-cpufreq,
 but most common usecases are already implemented.
 
 ## Features
@@ -238,6 +238,22 @@ performance for demanding tasks while conserving energy during light workloads.
 > [!TIP]
 > You can disable this logic with `enable_auto_turbo = false` to let the system
 > handle turbo boost natively when `turbo = "auto"`.
+
+#### Turbo Boost Behavior Table
+
+The table below explains how different combinations of `turbo` and
+`enable_auto_turbo` settings affect CPU turbo behavior:
+
+| Setting            | `enable_auto_turbo = true`                                                                               | `enable_auto_turbo = false`                                                                                  |
+| ------------------ | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `turbo = "always"` | **Always enabled**<br>Turbo is always active regardless of CPU load or temperature                       | **Always enabled**<br>Turbo is always active regardless of CPU load or temperature                           |
+| `turbo = "never"`  | **Always disabled**<br>Turbo is always disabled regardless of CPU load or temperature                    | **Always disabled**<br>Turbo is always disabled regardless of CPU load or temperature                        |
+| `turbo = "auto"`   | **Dynamically managed**<br>Superfreq enables/disables turbo based on CPU load and temperature thresholds | **System default**<br>Turbo is reset to system's default enabled state and is managed by the hardware/kernel |
+
+> [!NOTE]
+> When `turbo = "auto"` and `enable_auto_turbo = false`, Superfreq ensures that
+> any previous turbo state restrictions are removed, allowing the
+> hardware/kernel to manage turbo behavior according to its default algorithms.
 
 ### Adaptive Polling
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,12 @@ turbo = "auto"
 # Enable or disable automatic turbo management (when turbo = "auto")
 enable_auto_turbo = true
 # Custom thresholds for auto turbo management
-turbo_auto_settings = { load_threshold_high = 70.0, load_threshold_low = 30.0, temp_threshold_high = 75.0 }
+turbo_auto_settings = {
+    load_threshold_high = 70.0,
+    load_threshold_low = 30.0,
+    temp_threshold_high = 75.0,
+    initial_turbo_state = false,  # whether turbo should be initially enabled (false = disabled)
+}
 # Energy Performance Preference
 epp = "performance"
 # Energy Performance Bias (0-15 scale or named value)
@@ -174,7 +179,12 @@ governor = "powersave"
 turbo = "auto"
 # More conservative auto turbo settings on battery
 enable_auto_turbo = true
-turbo_auto_settings = { load_threshold_high = 80.0, load_threshold_low = 40.0, temp_threshold_high = 70.0 }
+turbo_auto_settings = {
+    load_threshold_high = 80.0,
+    load_threshold_low = 40.0,
+    temp_threshold_high = 70.0,
+    initial_turbo_state = false,  # start with turbo disabled on battery for power savings
+}
 epp = "power"
 epb = "balance_power"
 platform_profile = "low-power"
@@ -229,6 +239,8 @@ dynamically controls CPU turbo boost based on:
   exceeds `temp_threshold_high` (default 75°C)
 - **Hysteresis Control**: Prevents rapid toggling by maintaining previous state
   when load is between thresholds
+- **Configurable Initial State**: Sets the initial turbo state via
+  `initial_turbo_state` (default: disabled) before system load data is available
 - **Profile-Specific Settings**: Configure different thresholds for battery vs.
   AC power
 
@@ -314,10 +326,11 @@ While reporting issues, please attach the results from `superfreq debug`.
 Contributions to Superfreq are always welcome! Whether it's bug reports, feature
 requests, or code contributions, please feel free to contribute.
 
-If you are looking to reimplement features from auto_cpufreq, please consider
-opening an issue first and let us know what you have in mind. Certain features
-(such as the system tray) are deliberately ignored, and might not be desired in
-the codebase as they stand.
+> [!NOTE]
+> If you are looking to reimplement features from auto-cpufreq, please consider
+> opening an issue first and let us know what you have in mind. Certain features
+> (such as the system tray) are deliberately ignored, and might not be desired
+> in the codebase as they stand. Please discuss those features with us first :)
 
 ### Setup
 
@@ -332,9 +345,9 @@ nix develop
 ```
 
 Non-Nix users may get the appropriate Cargo and Rust versions from their package
-manager.
+manager, or using something like Rustup.
 
-### Formatting
+### Formatting & Lints
 
 Please make sure to run _at least_ `cargo fmt` inside the repository to make
 sure all of your code is properly formatted. For Nix code, please use Alejandra.

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -222,9 +222,7 @@ impl From<ProfileConfigToml> for ProfileConfig {
             min_freq_mhz: toml_config.min_freq_mhz,
             max_freq_mhz: toml_config.max_freq_mhz,
             platform_profile: toml_config.platform_profile,
-            turbo_auto_settings: toml_config
-                .turbo_auto_settings
-                .unwrap_or_default(),
+            turbo_auto_settings: toml_config.turbo_auto_settings.unwrap_or_default(),
             enable_auto_turbo: toml_config.enable_auto_turbo,
             battery_charge_thresholds: toml_config.battery_charge_thresholds,
         }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -51,6 +51,7 @@ pub struct ProfileConfig {
     pub max_freq_mhz: Option<u32>,
     pub platform_profile: Option<String>,
     pub turbo_auto_settings: Option<TurboAutoSettings>,
+    pub enable_auto_turbo: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub battery_charge_thresholds: Option<BatteryChargeThresholds>,
 }
@@ -66,6 +67,7 @@ impl Default for ProfileConfig {
             max_freq_mhz: None,     // no override
             platform_profile: None, // no override
             turbo_auto_settings: Some(TurboAutoSettings::default()),
+            enable_auto_turbo: default_enable_auto_turbo(),
             battery_charge_thresholds: None,
         }
     }
@@ -125,6 +127,8 @@ pub struct ProfileConfigToml {
     pub max_freq_mhz: Option<u32>,
     pub platform_profile: Option<String>,
     pub turbo_auto_settings: Option<TurboAutoSettings>,
+    #[serde(default = "default_enable_auto_turbo")]
+    pub enable_auto_turbo: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub battery_charge_thresholds: Option<BatteryChargeThresholds>,
 }
@@ -153,6 +157,7 @@ impl Default for ProfileConfigToml {
             max_freq_mhz: None,
             platform_profile: None,
             turbo_auto_settings: None,
+            enable_auto_turbo: default_enable_auto_turbo(),
             battery_charge_thresholds: None,
         }
     }
@@ -213,6 +218,7 @@ impl From<ProfileConfigToml> for ProfileConfig {
             turbo_auto_settings: toml_config
                 .turbo_auto_settings
                 .or_else(|| Some(TurboAutoSettings::default())),
+            enable_auto_turbo: toml_config.enable_auto_turbo,
             battery_charge_thresholds: toml_config.battery_charge_thresholds,
         }
     }
@@ -284,6 +290,10 @@ const fn default_log_level() -> LogLevel {
 
 const fn default_stats_file_path() -> Option<String> {
     None
+}
+
+const fn default_enable_auto_turbo() -> bool {
+    true
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -156,7 +156,7 @@ impl Default for ProfileConfigToml {
             min_freq_mhz: None,
             max_freq_mhz: None,
             platform_profile: None,
-            turbo_auto_settings: Some(TurboAutoSettings::default()),
+            turbo_auto_settings: None,
             enable_auto_turbo: default_enable_auto_turbo(),
             battery_charge_thresholds: None,
         }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -50,7 +50,9 @@ pub struct ProfileConfig {
     pub min_freq_mhz: Option<u32>,
     pub max_freq_mhz: Option<u32>,
     pub platform_profile: Option<String>,
+    #[serde(default)]
     pub turbo_auto_settings: TurboAutoSettings,
+    #[serde(default)]
     pub enable_auto_turbo: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub battery_charge_thresholds: Option<BatteryChargeThresholds>,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -50,7 +50,7 @@ pub struct ProfileConfig {
     pub min_freq_mhz: Option<u32>,
     pub max_freq_mhz: Option<u32>,
     pub platform_profile: Option<String>,
-    pub turbo_auto_settings: Option<TurboAutoSettings>,
+    pub turbo_auto_settings: TurboAutoSettings,
     pub enable_auto_turbo: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub battery_charge_thresholds: Option<BatteryChargeThresholds>,
@@ -66,7 +66,7 @@ impl Default for ProfileConfig {
             min_freq_mhz: None,     // no override
             max_freq_mhz: None,     // no override
             platform_profile: None, // no override
-            turbo_auto_settings: Some(TurboAutoSettings::default()),
+            turbo_auto_settings: TurboAutoSettings::default(),
             enable_auto_turbo: default_enable_auto_turbo(),
             battery_charge_thresholds: None,
         }
@@ -224,7 +224,7 @@ impl From<ProfileConfigToml> for ProfileConfig {
             platform_profile: toml_config.platform_profile,
             turbo_auto_settings: toml_config
                 .turbo_auto_settings
-                .or_else(|| Some(TurboAutoSettings::default())),
+                .unwrap_or_default(),
             enable_auto_turbo: toml_config.enable_auto_turbo,
             battery_charge_thresholds: toml_config.battery_charge_thresholds,
         }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -156,7 +156,7 @@ impl Default for ProfileConfigToml {
             min_freq_mhz: None,
             max_freq_mhz: None,
             platform_profile: None,
-            turbo_auto_settings: None,
+            turbo_auto_settings: Some(TurboAutoSettings::default()),
             enable_auto_turbo: default_enable_auto_turbo(),
             battery_charge_thresholds: None,
         }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -171,6 +171,9 @@ pub struct TurboAutoSettings {
     pub load_threshold_low: f32,
     #[serde(default = "default_temp_threshold_high")]
     pub temp_threshold_high: f32,
+    /// Initial turbo boost state when no previous state exists.
+    /// Set to `true` to start with turbo enabled, `false` to start with turbo disabled.
+    /// This is only used at first launch or after a reset.
     #[serde(default = "default_initial_turbo_state")]
     pub initial_turbo_state: bool,
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -124,6 +124,7 @@ pub struct ProfileConfigToml {
     pub min_freq_mhz: Option<u32>,
     pub max_freq_mhz: Option<u32>,
     pub platform_profile: Option<String>,
+    pub turbo_auto_settings: Option<TurboAutoSettings>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub battery_charge_thresholds: Option<BatteryChargeThresholds>,
 }
@@ -151,6 +152,7 @@ impl Default for ProfileConfigToml {
             min_freq_mhz: None,
             max_freq_mhz: None,
             platform_profile: None,
+            turbo_auto_settings: None,
             battery_charge_thresholds: None,
         }
     }
@@ -208,7 +210,9 @@ impl From<ProfileConfigToml> for ProfileConfig {
             min_freq_mhz: toml_config.min_freq_mhz,
             max_freq_mhz: toml_config.max_freq_mhz,
             platform_profile: toml_config.platform_profile,
-            turbo_auto_settings: Some(TurboAutoSettings::default()),
+            turbo_auto_settings: toml_config
+                .turbo_auto_settings
+                .or_else(|| Some(TurboAutoSettings::default())),
             battery_charge_thresholds: toml_config.battery_charge_thresholds,
         }
     }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -171,12 +171,15 @@ pub struct TurboAutoSettings {
     pub load_threshold_low: f32,
     #[serde(default = "default_temp_threshold_high")]
     pub temp_threshold_high: f32,
+    #[serde(default = "default_initial_turbo_state")]
+    pub initial_turbo_state: bool,
 }
 
 // Default thresholds for Auto turbo mode
 pub const DEFAULT_LOAD_THRESHOLD_HIGH: f32 = 70.0; // enable turbo if load is above this
 pub const DEFAULT_LOAD_THRESHOLD_LOW: f32 = 30.0; // disable turbo if load is below this
 pub const DEFAULT_TEMP_THRESHOLD_HIGH: f32 = 75.0; // disable turbo if temperature is above this
+pub const DEFAULT_INITIAL_TURBO_STATE: bool = false; // by default, start with turbo disabled
 
 const fn default_load_threshold_high() -> f32 {
     DEFAULT_LOAD_THRESHOLD_HIGH
@@ -187,6 +190,9 @@ const fn default_load_threshold_low() -> f32 {
 const fn default_temp_threshold_high() -> f32 {
     DEFAULT_TEMP_THRESHOLD_HIGH
 }
+const fn default_initial_turbo_state() -> bool {
+    DEFAULT_INITIAL_TURBO_STATE
+}
 
 impl Default for TurboAutoSettings {
     fn default() -> Self {
@@ -194,6 +200,7 @@ impl Default for TurboAutoSettings {
             load_threshold_high: DEFAULT_LOAD_THRESHOLD_HIGH,
             load_threshold_low: DEFAULT_LOAD_THRESHOLD_LOW,
             temp_threshold_high: DEFAULT_TEMP_THRESHOLD_HIGH,
+            initial_turbo_state: DEFAULT_INITIAL_TURBO_STATE,
         }
     }
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -213,23 +213,24 @@ fn get_available_governors() -> Result<Vec<String>> {
     ))
 }
 
+// FIXME: I think the Auto Turbo behaviour is still pretty confusing for the end-user
+// who might not have read the documentation in detail. We could just make the program
+// more verbose here, but I think this is a fundamental design flaw that I will want
+// to refactor in the future. For now though, I think this is a good-ish solution.
 pub fn set_turbo(setting: TurboSetting) -> Result<()> {
     let value_pstate = match setting {
         TurboSetting::Always => "0", // no_turbo = 0 means turbo is enabled
         TurboSetting::Never => "1",  // no_turbo = 1 means turbo is disabled
-        // Auto mode is handled at the engine level, not directly at the sysfs level
-        TurboSetting::Auto => {
-            debug!("Turbo Auto mode is managed by engine logic based on system conditions");
-            return Ok(());
-        }
+        // For Auto, we need to enable the hardware default (which is turbo enabled)
+        // and we reset to the system default when explicitly set to Auto
+        TurboSetting::Auto => "0", // Set to enabled (default hardware state) when Auto is requested
     };
     let value_boost = match setting {
         TurboSetting::Always => "1", // boost = 1 means turbo is enabled
         TurboSetting::Never => "0",  // boost = 0 means turbo is disabled
-        TurboSetting::Auto => {
-            debug!("Turbo Auto mode is managed by engine logic based on system conditions");
-            return Ok(());
-        }
+        // For Auto, we need to enable the hardware default (which is turbo enabled)
+        // and we reset to the system default when explicitly set to Auto
+        TurboSetting::Auto => "1", // Set to enabled (default hardware state) when Auto is requested
     };
 
     // AMD specific paths

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,6 +1,7 @@
 use crate::core::{GovernorOverrideMode, TurboSetting};
 use crate::util::error::ControlError;
 use core::str;
+use log::debug;
 use std::{fs, io, path::Path, string::ToString};
 
 pub type Result<T, E = ControlError> = std::result::Result<T, E>;
@@ -216,12 +217,19 @@ pub fn set_turbo(setting: TurboSetting) -> Result<()> {
     let value_pstate = match setting {
         TurboSetting::Always => "0", // no_turbo = 0 means turbo is enabled
         TurboSetting::Never => "1",  // no_turbo = 1 means turbo is disabled
-        TurboSetting::Auto => return Err(ControlError::InvalidValueError("Turbo Auto cannot be directly set via intel_pstate/no_turbo or cpufreq/boost. System default.".to_string())),
+        // Auto mode is handled at the engine level, not directly at the sysfs level
+        TurboSetting::Auto => {
+            debug!("Turbo Auto mode is managed by engine logic based on system conditions");
+            return Ok(());
+        }
     };
     let value_boost = match setting {
         TurboSetting::Always => "1", // boost = 1 means turbo is enabled
         TurboSetting::Never => "0",  // boost = 0 means turbo is disabled
-        TurboSetting::Auto => return Err(ControlError::InvalidValueError("Turbo Auto cannot be directly set via intel_pstate/no_turbo or cpufreq/boost. System default.".to_string())),
+        TurboSetting::Auto => {
+            debug!("Turbo Auto mode is managed by engine logic based on system conditions");
+            return Ok(());
+        }
     };
 
     // AMD specific paths

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,7 +1,6 @@
 use crate::core::{GovernorOverrideMode, TurboSetting};
 use crate::util::error::ControlError;
 use core::str;
-use log::debug;
 use std::{fs, io, path::Path, string::ToString};
 
 pub type Result<T, E = ControlError> = std::result::Result<T, E>;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,6 +1,7 @@
 use crate::core::{GovernorOverrideMode, TurboSetting};
 use crate::util::error::ControlError;
 use core::str;
+use log::debug;
 use std::{fs, io, path::Path, string::ToString};
 
 pub type Result<T, E = ControlError> = std::result::Result<T, E>;
@@ -212,44 +213,23 @@ fn get_available_governors() -> Result<Vec<String>> {
     ))
 }
 
-/// Controls CPU turbo boost behavior by writing to appropriate sysfs files.
-///
-/// # Parameters
-///
-/// * `setting` - The desired turbo boost setting:
-///   - `TurboSetting::Always`: Forces turbo boost to be always enabled
-///   - `TurboSetting::Never`: Forces turbo boost to be always disabled
-///   - `TurboSetting::Auto`: Has two distinct behaviors depending on the context:
-///     1. When called directly from user commands: Resets turbo to system default (enabled)
-///     2. When used with `enable_auto_turbo=true` in config: Managed dynamically by the engine
-///
-/// # Turbo Auto Mode Explained
-///
-/// When `TurboSetting::Auto` is used:
-/// - This function writes the same values as `TurboSetting::Always` to reset the hardware
-///   to its default state (turbo enabled)
-/// - The actual dynamic management happens at a higher level in the engine module
-///   when `enable_auto_turbo=true`
-/// - With `enable_auto_turbo=false`, the system's native turbo management takes over
-///
-///
-/// # Returns
-///
-/// * `Result<()>` - Success or an error if the operation failed
 pub fn set_turbo(setting: TurboSetting) -> Result<()> {
     let value_pstate = match setting {
         TurboSetting::Always => "0", // no_turbo = 0 means turbo is enabled
         TurboSetting::Never => "1",  // no_turbo = 1 means turbo is disabled
-        // For Auto, we need to enable the hardware default (which is turbo enabled)
-        // and we reset to the system default when explicitly set to Auto
-        TurboSetting::Auto => "0", // set to enabled (default hardware state) when Auto is requested
+        // Auto mode is handled at the engine level, not directly at the sysfs level
+        TurboSetting::Auto => {
+            debug!("Turbo Auto mode is managed by engine logic based on system conditions");
+            return Ok(());
+        }
     };
     let value_boost = match setting {
         TurboSetting::Always => "1", // boost = 1 means turbo is enabled
         TurboSetting::Never => "0",  // boost = 0 means turbo is disabled
-        // For Auto, we need to enable the hardware default (which is turbo enabled)
-        // and we reset to the system default when explicitly set to Auto
-        TurboSetting::Auto => "1", // set to enabled (default hardware state) when Auto is requested
+        TurboSetting::Auto => {
+            debug!("Turbo Auto mode is managed by engine logic based on system conditions");
+            return Ok(());
+        }
     };
 
     // AMD specific paths

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -94,7 +94,7 @@ impl TurboHysteresis {
 
     /// Update the turbo state for hysteresis
     fn update_state(&self, new_state: bool) {
-q        // First store the new state, then mark as initialized
+        // First store the new state, then mark as initialized
         // With this, any thread seeing initialized=true will also see the correct state
         self.previous_state.store(new_state, Ordering::Release);
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -81,6 +81,7 @@ impl TurboHysteresis {
         ) {
             Ok(_) => {
                 // We won the race to initialize - set the initial state
+                // Store the initial_state first, before marking as initialized
                 self.previous_state.store(initial_state, Ordering::Release);
                 initial_state
             }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -118,10 +118,12 @@ pub fn determine_and_apply_settings(
                     manage_auto_turbo(report, selected_profile_config)?;
                 } else {
                     debug!(
-                        "Auto turbo management disabled by configuration, using system default behavior"
+                        "Superfreq's dynamic turbo management is disabled by configuration. Ensuring system uses its default behavior for automatic turbo control."
                     );
+                    // Make sure the system is set to its default automatic turbo mode.
+                    // This is important if turbo was previously forced off.
                     try_apply_feature("Turbo boost", "system default (Auto)", || {
-                        cpu::set_turbo(turbo_setting)
+                        cpu::set_turbo(TurboSetting::Auto)
                     })?;
                 }
             }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -219,9 +219,9 @@ fn manage_auto_turbo(report: &SystemReport, config: &ProfileConfig) -> Result<()
     };
 
     // Get previous state safely using atomic operations
-    let has_previous_state = TURBO_STATE_INITIALIZED.load(Ordering::Relaxed);
+    let has_previous_state = TURBO_STATE_INITIALIZED.load(Ordering::Acquire);
     let previous_turbo_enabled = if has_previous_state {
-        Some(PREVIOUS_TURBO_STATE.load(Ordering::Relaxed))
+        Some(PREVIOUS_TURBO_STATE.load(Ordering::Acquire))
     } else {
         None
     };
@@ -272,8 +272,8 @@ fn manage_auto_turbo(report: &SystemReport, config: &ProfileConfig) -> Result<()
     };
 
     // Save the current state for next time using atomic operations
-    PREVIOUS_TURBO_STATE.store(enable_turbo, Ordering::Relaxed);
-    TURBO_STATE_INITIALIZED.store(true, Ordering::Relaxed);
+    PREVIOUS_TURBO_STATE.store(enable_turbo, Ordering::Release);
+    TURBO_STATE_INITIALIZED.store(true, Ordering::Release);
 
     // Apply the turbo setting
     let turbo_setting = if enable_turbo {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -113,8 +113,15 @@ pub fn determine_and_apply_settings(
         info!("Setting turbo to '{turbo_setting:?}'");
         match turbo_setting {
             TurboSetting::Auto => {
-                debug!("Managing turbo in auto mode based on system conditions");
-                manage_auto_turbo(report, selected_profile_config)?;
+                if selected_profile_config.enable_auto_turbo {
+                    debug!("Managing turbo in auto mode based on system conditions");
+                    manage_auto_turbo(report, selected_profile_config)?;
+                } else {
+                    debug!("Auto turbo management disabled by configuration, using system default behavior");
+                    try_apply_feature("Turbo boost", "system default (Auto)", || {
+                        cpu::set_turbo(turbo_setting)
+                    })?;
+                }
             }
             _ => {
                 try_apply_feature("Turbo boost", &format!("{turbo_setting:?}"), || {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -290,8 +290,8 @@ fn manage_auto_turbo(
     config: &ProfileConfig,
     on_ac_power: bool,
 ) -> Result<(), EngineError> {
-    // Get the auto turbo settings from the config, or use defaults
-    let turbo_settings = config.turbo_auto_settings.clone().unwrap_or_default();
+    // Get the auto turbo settings from the config
+    let turbo_settings = config.turbo_auto_settings.clone();
 
     // Validate the complete configuration to ensure it's usable
     validate_turbo_auto_settings(&turbo_settings)?;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -117,7 +117,9 @@ pub fn determine_and_apply_settings(
                     debug!("Managing turbo in auto mode based on system conditions");
                     manage_auto_turbo(report, selected_profile_config)?;
                 } else {
-                    debug!("Auto turbo management disabled by configuration, using system default behavior");
+                    debug!(
+                        "Auto turbo management disabled by configuration, using system default behavior"
+                    );
                     try_apply_feature("Turbo boost", "system default (Auto)", || {
                         cpu::set_turbo(turbo_setting)
                     })?;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -369,15 +369,25 @@ fn manage_auto_turbo(report: &SystemReport, config: &ProfileConfig) -> Result<()
         }
         // In indeterminate states or unknown previous state, use the configured initial state
         _ => {
-            info!(
-                "Auto Turbo: Using configured initial state ({})",
-                if turbo_settings.initial_turbo_state {
-                    "enabled"
-                } else {
-                    "disabled"
-                }
-            );
-            turbo_settings.initial_turbo_state
+            // If we have a previous state, maintain it for hysteresis even if load data is missing
+            if let Some(prev_state) = previous_turbo_enabled {
+                info!(
+                    "Auto Turbo: Maintaining previous state ({}) due to missing CPU data",
+                    if prev_state { "enabled" } else { "disabled" }
+                );
+                prev_state
+            } else {
+                // No previous state exists, fall back to configured initial state
+                info!(
+                    "Auto Turbo: Using configured initial state ({})",
+                    if turbo_settings.initial_turbo_state {
+                        "enabled"
+                    } else {
+                        "disabled"
+                    }
+                );
+                turbo_settings.initial_turbo_state
+            }
         }
     };
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -434,10 +434,14 @@ fn manage_auto_turbo(
 }
 
 fn validate_turbo_auto_settings(settings: &TurboAutoSettings) -> Result<(), EngineError> {
-    // Validate load thresholds
-    if settings.load_threshold_high <= settings.load_threshold_low {
+    // Validate load thresholds (0-100 % and high > low)
+    if settings.load_threshold_high <= settings.load_threshold_low
+        || settings.load_threshold_high > 100.0
+        || settings.load_threshold_low < 0.0
+        || settings.load_threshold_low > 100.0
+    {
         return Err(EngineError::ConfigurationError(
-            "Invalid turbo auto settings: high threshold must be greater than low threshold"
+            "Invalid turbo auto settings: load thresholds must be in 0-100% and high > low"
                 .to_string(),
         ));
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -168,13 +168,13 @@ pub fn determine_and_apply_settings(
 
     // Determine AC/Battery status once, early in the function
     // For desktops (no batteries), we should always use the AC power profile
-    // For laptops, we check if any battery is present and not connected to AC
+    // For laptops, we check if all batteries report connected to AC
     let on_ac_power = if report.batteries.is_empty() {
         // No batteries means desktop/server, always on AC
         true
     } else {
-        // Check if any battery reports AC connected
-        report.batteries.iter().any(|b| b.ac_connected)
+        // Check if all batteries report AC connected
+        report.batteries.iter().all(|b| b.ac_connected)
     };
 
     let selected_profile_config: &ProfileConfig;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -300,10 +300,10 @@ fn manage_auto_turbo(
     on_ac_power: bool,
 ) -> Result<(), EngineError> {
     // Get the auto turbo settings from the config
-    let turbo_settings = config.turbo_auto_settings.clone();
+    let turbo_settings = &config.turbo_auto_settings;
 
     // Validate the complete configuration to ensure it's usable
-    validate_turbo_auto_settings(&turbo_settings)?;
+    validate_turbo_auto_settings(turbo_settings)?;
 
     // Get average CPU temperature and CPU load
     let cpu_temp = report.cpu_global.average_temperature_celsius;
@@ -440,22 +440,14 @@ fn manage_auto_turbo(
 }
 
 fn validate_turbo_auto_settings(settings: &TurboAutoSettings) -> Result<(), EngineError> {
-    // Validate load thresholds (0-100 % and high > low)
     if settings.load_threshold_high <= settings.load_threshold_low
         || settings.load_threshold_high > 100.0
         || settings.load_threshold_low < 0.0
         || settings.load_threshold_low > 100.0
     {
         return Err(EngineError::ConfigurationError(
-            "Invalid turbo auto settings: load thresholds must be in 0-100% and high > low"
+            "Invalid turbo auto settings: load thresholds must be between 0 % and 100 % with high > low"
                 .to_string(),
-        ));
-    }
-
-    // Validate range of load thresholds (should be 0-100%)
-    if settings.load_threshold_high > 100.0 || settings.load_threshold_low < 0.0 {
-        return Err(EngineError::ConfigurationError(
-            "Invalid turbo auto settings: load thresholds must be between 0% and 100%".to_string(),
         ));
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -202,20 +202,21 @@ pub fn determine_and_apply_settings(
         }
     }
 
+    // Determine AC/Battery status once for the entire function
+    let on_ac_power = if report.batteries.is_empty() {
+        // No batteries means desktop/server, always on AC
+        true
+    } else {
+        // Check if any battery reports AC connected
+        report.batteries.iter().any(|b| b.ac_connected)
+    };
+
     if let Some(turbo_setting) = selected_profile_config.turbo {
         info!("Setting turbo to '{turbo_setting:?}'");
         match turbo_setting {
             TurboSetting::Auto => {
                 if selected_profile_config.enable_auto_turbo {
                     debug!("Managing turbo in auto mode based on system conditions");
-                    // Determine AC status and pass it to manage_auto_turbo
-                    let on_ac_power = if report.batteries.is_empty() {
-                        // No batteries means desktop/server, always on AC
-                        true
-                    } else {
-                        // Check if any battery reports AC connected
-                        report.batteries.iter().any(|b| b.ac_connected)
-                    };
                     manage_auto_turbo(report, selected_profile_config, on_ac_power)?;
                 } else {
                     debug!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,7 @@ fn main() -> Result<(), AppError> {
 
                 format_section("CPU Global Info");
                 println!(
-                    "Current Governor:   {}",
+                    "Current Governor:    {}",
                     report
                         .cpu_global
                         .current_governor
@@ -148,11 +148,11 @@ fn main() -> Result<(), AppError> {
                         .unwrap_or("N/A")
                 );
                 println!(
-                    "Available Governors: {}",
+                    "Available Governors: {}", // 21 length baseline
                     report.cpu_global.available_governors.join(", ")
                 );
                 println!(
-                    "Turbo Status:       {}",
+                    "Turbo Status:        {}",
                     match report.cpu_global.turbo_status {
                         Some(true) => "Enabled",
                         Some(false) => "Disabled",
@@ -161,15 +161,15 @@ fn main() -> Result<(), AppError> {
                 );
 
                 println!(
-                    "EPP:                {}",
+                    "EPP:                 {}",
                     report.cpu_global.epp.as_deref().unwrap_or("N/A")
                 );
                 println!(
-                    "EPB:                {}",
+                    "EPB:                 {}",
                     report.cpu_global.epb.as_deref().unwrap_or("N/A")
                 );
                 println!(
-                    "Platform Profile:   {}",
+                    "Platform Profile:    {}",
                     report
                         .cpu_global
                         .platform_profile
@@ -177,7 +177,7 @@ fn main() -> Result<(), AppError> {
                         .unwrap_or("N/A")
                 );
                 println!(
-                    "CPU Temperature:    {}",
+                    "CPU Temperature:     {}",
                     report.cpu_global.average_temperature_celsius.map_or_else(
                         || "N/A (No sensor detected)".to_string(),
                         |t| format!("{t:.1}°C")


### PR DESCRIPTION
Adds proper implementation of `TurboSetting::Auto` mode that dynamically manages turbo boost based on CPU load and temperature. This feature automatically enables turbo during high CPU load (>70%) for maximum performance, disables it during light tasks (<30%) to save power, and enforces thermal limits by disabling turbo when CPU temperature exceeds a configurable threshold (default 75°C). 

Users can customize these thresholds through configuration file. Closes #4 