### PR TITLE
watt: implement single-instance lock mechanism for watt daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
 dependencies = [
  "dispatch2",
- "nix",
+ "nix 0.30.1",
  "windows-sys",
 ]
 
@@ -406,6 +406,18 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -826,6 +838,7 @@ dependencies = [
  "derive_more",
  "env_logger",
  "log",
+ "nix 0.31.1",
  "num_cpus",
  "proptest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ clap                  = { features = [ "derive", "env" ], version = "4.5.50" }
 clap-verbosity-flag   = "3.0.4"
 clap_complete         = "4.5.59"
 clap_complete_nushell = "4.5.9"
-ctrlc                 = "3.5.0"
+ctrlc                 = "3.5.1"
 derive_more           = { features = [ "full" ], version = "2.0.1" }
 env_logger            = "0.11.8"
 log                   = "0.4.28"
+nix                   = { features = [ "fs" ], version = "0.31.1" }
 num_cpus              = "1.17.0"
 serde                 = { features = [ "derive" ], version = "1.0.228" }
 thiserror             = "2.0.17"

--- a/watt/Cargo.toml
+++ b/watt/Cargo.toml
@@ -21,6 +21,7 @@ ctrlc.workspace               = true
 derive_more.workspace         = true
 env_logger.workspace          = true
 log.workspace                 = true
+nix.workspace                 = true
 num_cpus.workspace            = true
 serde.workspace               = true
 thiserror.workspace           = true

--- a/watt/lock.rs
+++ b/watt/lock.rs
@@ -1,0 +1,179 @@
+use std::{
+  error::Error,
+  fmt,
+  fs::{
+    self,
+    File,
+    OpenOptions,
+  },
+  io::Write,
+  ops,
+  path::{
+    Path,
+    PathBuf,
+  },
+  process,
+};
+
+#[cfg(unix)] use nix::fcntl::{
+  Flock,
+  FlockArg,
+};
+
+#[cfg(not(unix))]
+compile_error!("watt is only supported on Unix-like systems");
+
+pub struct LockFile {
+  lock: Flock<File>,
+  path: PathBuf,
+}
+
+#[derive(Debug)]
+pub struct LockFileError {
+  pub path: PathBuf,
+  pid:      u32,
+}
+
+impl fmt::Display for LockFileError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    if self.pid == 0 {
+      write!(f, "failed to acquire lock at {}", self.path.display())
+    } else {
+      write!(f, "another watt daemon is running (PID: {})", self.pid)
+    }
+  }
+}
+
+impl Error for LockFileError {}
+
+impl ops::Deref for LockFile {
+  type Target = File;
+
+  fn deref(&self) -> &Self::Target {
+    &self.lock
+  }
+}
+
+impl ops::DerefMut for LockFile {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.lock
+  }
+}
+
+impl LockFile {
+  pub fn path(&self) -> &Path {
+    &self.path
+  }
+
+  pub fn acquire(
+    lock_path: &Path,
+    force: bool,
+  ) -> Result<Option<Self>, LockFileError> {
+    let pid = process::id();
+
+    #[allow(clippy::suspicious_open_options)]
+    let file = OpenOptions::new()
+      .create(true)
+      .read(true)
+      .write(true)
+      .open(lock_path)
+      .map_err(|error| {
+        log::error!(
+          "failed to open lock file at {}: {}",
+          lock_path.display(),
+          error
+        );
+        LockFileError {
+          path: lock_path.to_owned(),
+          pid:  0,
+        }
+      })?;
+
+    let mut lock = match Flock::lock(file, FlockArg::LockExclusiveNonblock) {
+      Ok(lock) => lock,
+      Err((_, nix::errno::Errno::EWOULDBLOCK)) => {
+        let Some(existing_pid) = Self::read_pid(lock_path) else {
+          if force {
+            log::warn!(
+              "could not determine PID of existing watt instance, starting \
+               anyway",
+            );
+            return Ok(None);
+          }
+
+          return Err(LockFileError {
+            path: lock_path.to_owned(),
+            pid:  0,
+          });
+        };
+
+        if force {
+          log::warn!(
+            "another watt instance is running (PID: {existing_pid}), starting \
+             anyway",
+          );
+          return Ok(None);
+        }
+
+        return Err(LockFileError {
+          path: lock_path.to_owned(),
+          pid:  existing_pid,
+        });
+      },
+
+      Err((_, error)) => {
+        log::error!("failed to acquire lock: {}", error);
+        return Err(LockFileError {
+          path: lock_path.to_owned(),
+          pid:  0,
+        });
+      },
+    };
+
+    if let Err(e) = lock.set_len(0) {
+      log::error!("failed to truncate lock file: {}", e);
+      return Err(LockFileError {
+        path: lock_path.to_owned(),
+        pid:  0,
+      });
+    }
+
+    if let Err(e) = lock.write_all(format!("{pid}\n").as_bytes()) {
+      log::error!("failed to write PID to lock file: {}", e);
+      return Err(LockFileError {
+        path: lock_path.to_owned(),
+        pid:  0,
+      });
+    }
+
+    if let Err(e) = lock.sync_all() {
+      log::error!("failed to sync lock file: {}", e);
+      return Err(LockFileError {
+        path: lock_path.to_owned(),
+        pid:  0,
+      });
+    }
+
+    Ok(Some(LockFile {
+      lock,
+      path: lock_path.to_owned(),
+    }))
+  }
+
+  fn read_pid(lock_path: &Path) -> Option<u32> {
+    match fs::read_to_string(lock_path) {
+      Ok(content) => content.trim().parse().ok(),
+      Err(_) => None,
+    }
+  }
+
+  pub fn release(&mut self) {
+    let _ = fs::remove_file(&self.path);
+  }
+}
+
+impl Drop for LockFile {
+  fn drop(&mut self) {
+    self.release();
+  }
+}


### PR DESCRIPTION
This was probably something we should've implemented earlier. While not *too* likely, it's possible that there will be multiple Watt instances running simultaneously, which can create access issues if two of them try to write a sysfs path at the same time. This PR introduces process locking to the Watt daemon in order to prevent multiple instances from running simultaneously.

This is done in the new `watt::lock` module that manages a PID file lock, and a new `--force` flag has been added for when this behaviour is explicitly desired.

Change-Id: Ideaf221f690c7bc694ca1f171385bfde6a6a6964