### PR TITLE
cpu: `energy_performance_bias` -> `energy_perf_bias`

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Predicates check if a specific value is available on the system:
 ```toml
 if.is-governor-available = "powersave"
 if.is-energy-performance-preference-available = "balance_performance"
-if.is-energy-performance-bias-available = "5"
+if.is-energy-perf-bias-available = "5"
 if.is-platform-profile-available = "low-power"
 if.is-driver-loaded = "intel_pstate"
 ```
@@ -323,7 +323,7 @@ Settings can be conditionally applied based on availability:
 ```toml
 cpu.governor = { if.is-governor-available = "powersave", then = "powersave" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "balance_performance", then = "balance_performance" }
-cpu.energy-performance-bias = { if.is-energy-performance-bias-available = "5", then = "5" }
+cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "5", then = "5" }
 cpu.frequency-mhz-maximum = { if = "?frequency-available", then = 2000 }
 cpu.turbo = { if = "?turbo-available", then = true }
 ```
@@ -338,7 +338,7 @@ If the condition is not met, the setting will not be applied.
 if = { is-more-than = 85.0, value = "$cpu-temperature" }
 priority = 100
 
-cpu.energy-performance-bias = { if.is-energy-performance-bias-available = "power", then = "power" }
+cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "power", then = "power" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
 cpu.frequency-mhz-maximum = { if = "?frequency-available", then = 2000 }
 cpu.governor = { if.is-governor-available = "powersave", then = "powersave" }
@@ -349,7 +349,7 @@ cpu.turbo = { if = "?turbo-available", then = false }
 if.all = [ "?discharging", { is-less-than = 0.3, value = "%power-supply-charge" } ]
 priority = 90
 
-cpu.energy-performance-bias = { if.is-energy-performance-bias-available = "power", then = "power" }
+cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "power", then = "power" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
 cpu.frequency-mhz-maximum = 800
 cpu.governor = { if.is-governor-available = "powersave", then = "powersave" }
@@ -365,7 +365,7 @@ if.all = [
 ]
 priority = 80
 
-cpu.energy-performance-bias = { if.is-energy-performance-bias-available = "performance", then = "performance" }
+cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "performance", then = "performance" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "performance", then = "performance" }
 cpu.governor = { if.is-governor-available = "performance", then = "performance" }
 cpu.turbo = { if = "?turbo-available", then = true }
@@ -379,7 +379,7 @@ if.all = [
 ]
 priority = 70
 
-cpu.energy-performance-bias = { if.is-energy-performance-bias-available = "balance_performance", then = "balance_performance" }
+cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "balance-performance", then = "balance-performance" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "performance", then = "performance" }
 cpu.governor = { if.is-governor-available = "performance", then = "performance" }
 cpu.turbo = { if = "?turbo-available", then = true }
@@ -392,7 +392,7 @@ if.all = [
 ]
 priority = 60
 
-cpu.energy-performance-bias = { if.is-energy-performance-bias-available = "balance_performance", then = "balance_performance" }
+cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "balance-performance", then = "balance-performance" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "balance_performance", then = "balance_performance" }
 cpu.governor = { if.is-governor-available = "schedutil", then = "schedutil" }
 
@@ -404,7 +404,7 @@ if.all = [
 ]
 priority = 50
 
-cpu.energy-performance-bias = { if.is-energy-performance-bias-available = "power", then = "power" }
+cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "power", then = "power" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
 cpu.governor = { if.is-governor-available = "powersave", then = "powersave" }
 cpu.turbo = { if = "?turbo-available", then = false }
@@ -414,7 +414,7 @@ cpu.turbo = { if = "?turbo-available", then = false }
 if = { is-more-than = 300.0, value = "$cpu-idle-seconds" }
 priority = 40
 
-cpu.energy-performance-bias = { if.is-energy-performance-bias-available = "power", then = "power" }
+cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "power", then = "power" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
 cpu.frequency-mhz-maximum = { if = "?frequency-available", then = 1600 }
 cpu.governor = { if.is-governor-available = "powersave", then = "powersave" }
@@ -425,7 +425,7 @@ cpu.turbo = { if = "?turbo-available", then = false }
 if.all = [ "?discharging", { is-less-than = 0.5, value = "%power-supply-charge" } ]
 priority = 30
 
-cpu.energy-performance-bias = { if.is-energy-performance-bias-available = "power", then = "power" }
+cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "power", then = "power" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
 cpu.frequency-mhz-maximum = { if = "?frequency-available", then = 2000 }
 cpu.governor = { if.is-governor-available = "powersave", then = "powersave" }
@@ -437,7 +437,7 @@ power.platform-profile = { if.is-platform-profile-available = "low-power", then 
 if = "?discharging"
 priority = 20
 
-cpu.energy-performance-bias = { if.is-energy-performance-bias-available = "balance_power", then = "balance_power" }
+cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "balance-power", then = "balance-power" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
 cpu.frequency-mhz-maximum = { if = "?frequency-available", then = 1800 }
 cpu.frequency-mhz-minimum = { if = "?frequency-available", then = 200 }
@@ -448,7 +448,7 @@ cpu.turbo = { if = "?turbo-available", then = false }
 [[rule]]
 priority = 0
 
-cpu.energy-performance-bias = { if.is-energy-performance-bias-available = "balance_performance", then = "balance_performance" }
+cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "balance-performance", then = "balance-performance" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "balance_performance", then = "balance_performance" }
 cpu.governor = { if.is-governor-available = "schedutil", then = "schedutil" }
 ```
@@ -475,12 +475,12 @@ Available CPU configuration options:
   cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "balance_performance", then = "balance_performance" }
   ```
 
-- `energy-performance-bias` - EPB setting (`performance`, `balance_performance`,
-  `balance_power`, `power`, etc.). You can conditionally set an EPB only if it
+- `energy-perf-bias` - EPB setting (`performance`, `balance-performance`,
+  `balance-power`, `power`, etc.). You can conditionally set an EPB only if it
   is available using:
 
   ```toml
-  cpu.energy-performance-bias = { if.is-energy-performance-bias-available = "5", then = "5" }
+  cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "5", then = "5" }
   ```
 
 - `frequency-mhz-minimum` - Minimum CPU frequency in MHz. Can use conditional

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -51,7 +51,7 @@ pub struct CpusDelta {
   ///
   /// Type: `String`.
   #[serde(skip_serializing_if = "is_default")]
-  pub energy_performance_bias:       Option<Expression>,
+  pub energy_perf_bias:              Option<Expression>,
 
   /// Set minimum CPU frequency in MHz.
   ///
@@ -142,15 +142,14 @@ impl CpusDelta {
           Some(energy_performance_preference);
       }
 
-      if let Some(energy_performance_bias) = &self.energy_performance_bias
-        && let Some(energy_performance_bias) =
-          energy_performance_bias.eval(&state)?
+      if let Some(energy_perf_bias) = &self.energy_perf_bias
+        && let Some(energy_perf_bias) = energy_perf_bias.eval(&state)?
       {
-        let energy_performance_bias = energy_performance_bias
+        let energy_perf_bias = energy_perf_bias
           .try_into_string()
-          .context("`cpu.energy-performance-bias` was not a string")?;
+          .context("`cpu.energy-perf-bias` was not a string")?;
 
-        delta.energy_performance_bias = Some(energy_performance_bias);
+        delta.energy_perf_bias = Some(energy_perf_bias);
       }
 
       if let Some(frequency_mhz_minimum) = &self.frequency_mhz_minimum
@@ -409,8 +408,8 @@ pub enum Expression {
     #[serde(rename = "is-energy-performance-preference-available")]
     value: Box<Expression>,
   },
-  IsEnergyPerformanceBiasAvailable {
-    #[serde(rename = "is-energy-performance-bias-available")]
+  IsEnergyPerfBiasAvailable {
+    #[serde(rename = "is-energy-perf-bias-available")]
     value: Box<Expression>,
   },
   IsPlatformProfileAvailable {
@@ -702,7 +701,7 @@ impl Expression {
 
         Boolean(available)
       },
-      IsEnergyPerformanceBiasAvailable { value } => {
+      IsEnergyPerfBiasAvailable { value } => {
         let value = eval!(value);
         let value = value.try_into_string()?;
 
@@ -1077,7 +1076,7 @@ mod tests {
           for_: None,
           governor: None,
           energy_performance_preference: None,
-          energy_performance_bias: None,
+          energy_perf_bias: None,
           frequency_mhz_minimum: None,
           frequency_mhz_maximum: Some(Expression::Number(value)),
           turbo: None,
@@ -1144,7 +1143,7 @@ mod tests {
       for_:                          None,
       governor:                      None,
       energy_performance_preference: None,
-      energy_performance_bias:       None,
+      energy_perf_bias:              None,
       frequency_mhz_minimum:         None,
       frequency_mhz_maximum:         Some(Expression::Multiply {
         a: Box::new(Expression::CpuFrequencyMaximum),

--- a/watt/config.toml
+++ b/watt/config.toml
@@ -8,7 +8,7 @@ name     = "emergency-thermal-protection"
 if       = { is-more-than = 85.0, value = "$cpu-temperature" }
 priority = 100
 
-cpu.energy-performance-bias       = { if.is-energy-performance-bias-available = "power", then = "power" }
+cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "power", then = "power" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
 cpu.frequency-mhz-maximum         = { if = "?frequency-available", then = 2000 }
 cpu.governor                      = { if.is-governor-available = "powersave", then = "powersave" }
@@ -19,7 +19,7 @@ name     = "critical-battery-preservation"
 if.all   = [ "?discharging", { is-less-than = 0.3, value = "%power-supply-charge" } ]
 priority = 90
 
-cpu.energy-performance-bias       = { if.is-energy-performance-bias-available = "power", then = "power" }
+cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "power", then = "power" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
 cpu.governor                      = { if.is-governor-available = "powersave", then = "powersave" }
 cpu.turbo                         = { if = "?turbo-available", then = false }
@@ -34,7 +34,7 @@ if.all = [
 ]
 priority = 80
 
-cpu.energy-performance-bias       = { if.all = [{ not.is-driver-loaded = "intel_pstate" }, { is-energy-performance-bias-available = "performance" }], then = "performance" }
+cpu.energy-perf-bias              = { if.all = [{ not.is-driver-loaded = "intel_pstate" }, { is-energy-perf-bias-available = "performance" }], then = "performance" }
 cpu.energy-performance-preference = { if.all = [{ not.is-driver-loaded = "intel_pstate" }, { is-energy-performance-preference-available = "performance" }], then = "performance" }
 cpu.governor                      = { if.is-governor-available = "performance", then = "performance" }
 cpu.turbo                         = { if = "?turbo-available", then = true }
@@ -48,7 +48,7 @@ if.all = [
 ]
 priority = 70
 
-cpu.energy-performance-bias       = { if.all = [{ not.is-driver-loaded = "intel_pstate" }, { is-energy-performance-bias-available = "balance_performance" }], then = "balance_performance" }
+cpu.energy-perf-bias              = { if.all = [{ not.is-driver-loaded = "intel_pstate" }, { is-energy-perf-bias-available = "balance-performance" }], then = "balance-performance" }
 cpu.energy-performance-preference = { if.all = [{ not.is-driver-loaded = "intel_pstate" }, { is-energy-performance-preference-available = "performance" }], then = "performance" }
 cpu.governor                      = { if.is-governor-available = "performance", then = "performance" }
 cpu.turbo                         = { if = "?turbo-available", then = true }
@@ -61,7 +61,7 @@ if.all = [
 ]
 priority = 60
 
-cpu.energy-performance-bias       = { if.is-energy-performance-bias-available = "balance_performance", then = "balance_performance" }
+cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "balance-performance", then = "balance-performance" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "balance_performance", then = "balance_performance" }
 cpu.governor                      = { if.is-governor-available = "schedutil", then = "schedutil" }
 
@@ -73,7 +73,7 @@ if.all = [
 ]
 priority = 50
 
-cpu.energy-performance-bias       = { if.is-energy-performance-bias-available = "power", then = "power" }
+cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "power", then = "power" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
 cpu.governor                      = { if.is-governor-available = "powersave", then = "powersave" }
 cpu.turbo                         = { if = "?turbo-available", then = false }
@@ -83,7 +83,7 @@ name     = "extended-idle-power-saving"
 if       = { is-more-than = 300.0, value = "$cpu-idle-seconds" }
 priority = 40
 
-cpu.energy-performance-bias       = { if.is-energy-performance-bias-available = "power", then = "power" }
+cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "power", then = "power" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
 cpu.frequency-mhz-maximum         = { if = "?frequency-available", then = 1600 }
 cpu.governor                      = { if.is-governor-available = "powersave", then = "powersave" }
@@ -94,7 +94,7 @@ name     = "discharging-battery-conservation"
 if.all   = [ "?discharging", { is-less-than = 0.5, value = "%power-supply-charge" } ]
 priority = 30
 
-cpu.energy-performance-bias       = { if.is-energy-performance-bias-available = "power", then = "power" }
+cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "power", then = "power" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
 cpu.frequency-mhz-maximum         = { if = "?frequency-available", then = 2000 }
 cpu.governor                      = { if.is-governor-available = "powersave", then = "powersave" }
@@ -106,7 +106,7 @@ name     = "battery-balanced"
 if       = "?discharging"
 priority = 20
 
-cpu.energy-performance-bias       = { if.is-energy-performance-bias-available = "balance_power", then = "balance_power" }
+cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "balance-performance", then = "balance-performance" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
 cpu.frequency-mhz-maximum         = { if = "?frequency-available", then = 1800 }
 cpu.frequency-mhz-minimum         = { if = "?frequency-available", then = 200 }
@@ -115,7 +115,7 @@ cpu.turbo                         = { if = "?turbo-available", then = false }
 
 [[rule]]
 name                              = "default-balanced"
-cpu.energy-performance-bias       = { if.is-energy-performance-bias-available = "balance_performance", then = "balance_performance" }
+cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "balance-performance", then = "balance-performance" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "balance_performance", then = "balance_performance" }
 cpu.governor                      = { if.is-governor-available = "schedutil", then = "schedutil" }
 priority                          = 0


### PR DESCRIPTION
I found a few issues with EPB:
- The correct path is `/sys/devices/system/cpu/cpu{number}/power/energy_perf_bias`, not `/sys/devices/system/cpu/cpu{number}/cpufreq/energy_performance_bias`.
- The list of available EPBs was incorrect, because it didn't include `0` and `normal`, and that the alternative forms with underscore (`balance_performance`, `balance_power`) are not valid settings.

You can verify these details in the [linux kernel documentation](https://www.kernel.org/doc/html/latest/admin-guide/pm/intel_epb.html).

I also did an `s/energy-performance-bias/energy-perf-bias/` to remain consistent with the sysfs path. I can undo this if you'd like.