### PR TITLE
watt: initial d-bus interface work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,13 +129,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
-name = "block2"
-version = "0.6.2"
+name = "bumpalo"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
-dependencies = [
- "objc2",
-]
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"
@@ -191,26 +228,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "ctrlc"
-version = "3.5.2"
+name = "concurrent-queue"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
- "dispatch2",
- "nix",
- "windows-sys",
+ "crossbeam-utils",
 ]
 
 [[package]]
-name = "dispatch2"
-version = "0.3.1"
+name = "crossbeam-utils"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
- "bitflags",
- "block2",
- "libc",
- "objc2",
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -253,6 +309,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +346,49 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -321,6 +441,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "humantime"
@@ -411,6 +537,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +577,26 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "nix"
@@ -472,21 +630,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +640,28 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -530,6 +695,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -668,6 +842,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,12 +909,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -768,6 +985,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "tracing",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +1037,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +1062,48 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys",
+]
 
 [[package]]
 name = "unarray"
@@ -831,6 +1130,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +1148,12 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -855,6 +1171,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -898,7 +1259,6 @@ dependencies = [
  "anyhow",
  "clap",
  "clap-verbosity-flag",
- "ctrlc",
  "env_logger",
  "humantime",
  "jiff",
@@ -907,8 +1267,10 @@ dependencies = [
  "num_cpus",
  "proptest",
  "serde",
+ "tokio",
  "toml",
  "yansi",
+ "zbus",
 ]
 
 [[package]]
@@ -931,6 +1293,9 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -1046,6 +1411,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+dependencies = [
+ "async-broadcast",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,3 +1491,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,16 +19,17 @@ clap                  = { features = [ "derive", "env" ], version = "4.6.1" }
 clap-verbosity-flag   = "3.0.4"
 clap_complete         = "4.6.2"
 clap_complete_nushell = "4.6.0"
-ctrlc                 = "3.5.2"
 env_logger            = "0.11.10"
 humantime             = "2.3.0"
 jiff                  = "0.2.24"
 log                   = "0.4.29"
-nix                   = { features = [ "fs" ], version = "0.31.2" }
+nix                   = { features = [ "fs", "process", "signal" ], version = "0.31.2" }
 num_cpus              = "1.17.0"
 serde                 = { features = [ "derive" ], version = "1.0.228" }
 toml                  = "1.1.2"
 yansi                 = { features = [ "detect-env", "detect-tty" ], version = "1.0.1" }
+zbus                  = { default-features = false, features = [ "tokio" ], version = "5.13.2" }
+tokio                 = { features = [ "macros", "rt-multi-thread", "signal", "time" ], version = "1.49.0" }
 
 [profile.release]
 codegen-units = 1

--- a/dbus/net.hadess.PowerProfiles.conf
+++ b/dbus/net.hadess.PowerProfiles.conf
@@ -1,0 +1,19 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <!-- Allow root to own the PowerProfiles name -->
+  <policy user="root">
+    <allow own="net.hadess.PowerProfiles"/>
+    <allow own="dev.notashelf.Watt"/>
+    <allow send_destination="net.hadess.PowerProfiles"/>
+    <allow send_destination="dev.notashelf.Watt"/>
+  </policy>
+
+  <!-- Allow any user to interact with the service -->
+  <policy context="default">
+    <allow send_destination="net.hadess.PowerProfiles"/>
+    <allow send_destination="dev.notashelf.Watt"/>
+    <allow receive_sender="net.hadess.PowerProfiles"/>
+    <allow receive_sender="dev.notashelf.Watt"/>
+  </policy>
+</busconfig>

--- a/watt/Cargo.toml
+++ b/watt/Cargo.toml
@@ -17,7 +17,6 @@ path = "main.rs"
 anyhow.workspace              = true
 clap.workspace                = true
 clap-verbosity-flag.workspace = true
-ctrlc.workspace               = true
 env_logger.workspace          = true
 humantime.workspace           = true
 jiff.workspace                = true
@@ -27,6 +26,8 @@ num_cpus.workspace            = true
 serde.workspace               = true
 toml.workspace                = true
 yansi.workspace               = true
+zbus.workspace                = true
+tokio.workspace               = true
 
 [dev-dependencies]
 proptest = "1.9.0"

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -432,6 +432,7 @@ mod expression {
   named!(battery_health => "%battery-health");
 
   named!(discharging => "?discharging");
+  named!(power_profile_preference => "$power-profile-preference");
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -537,6 +538,9 @@ pub enum Expression {
 
   #[serde(with = "expression::discharging")]
   Discharging,
+
+  #[serde(with = "expression::power_profile_preference")]
+  PowerProfilePreference,
 
   Boolean(bool),
 
@@ -705,6 +709,8 @@ pub struct EvalState<'peripherals, 'context> {
   pub battery_health: Option<f64>,
 
   pub discharging: bool,
+
+  pub power_profile_preference: crate::profile::PowerProfile,
 
   pub context: EvalContext<'context>,
 
@@ -931,6 +937,10 @@ impl Expression {
       },
 
       Discharging => Boolean(state.discharging),
+
+      PowerProfilePreference => {
+        String(state.power_profile_preference.as_str().to_owned())
+      },
 
       literal @ (Boolean(_) | Number(_) | String(_)) => literal.clone(),
 
@@ -1229,6 +1239,7 @@ mod tests {
         battery_cycles: Some(100.0),
         battery_health: Some(0.95),
         discharging: false,
+        power_profile_preference: crate::profile::PowerProfile::Balanced,
         context: EvalContext::Cpu(&cpu),
         cpus: &cpus,
         power_supplies: &power_supplies,
@@ -1319,6 +1330,7 @@ mod tests {
       battery_cycles:              Some(100.0),
       battery_health:              Some(0.95),
       discharging:                 false,
+      power_profile_preference:    crate::profile::PowerProfile::Balanced,
       context:                     EvalContext::Cpu(&cpu),
       cpus:                        &cpus,
       power_supplies:              &power_supplies,
@@ -1397,6 +1409,7 @@ mod tests {
       battery_cycles:              None,
       battery_health:              None,
       discharging:                 false,
+      power_profile_preference:    crate::profile::PowerProfile::Balanced,
       context:                     EvalContext::Cpu(&cpu),
       cpus:                        &cpus,
       power_supplies:              &power_supplies,

--- a/watt/dbus/mod.rs
+++ b/watt/dbus/mod.rs
@@ -1,0 +1,3 @@
+pub mod ppd;
+pub mod server;
+pub mod watt;

--- a/watt/dbus/ppd.rs
+++ b/watt/dbus/ppd.rs
@@ -1,0 +1,183 @@
+use std::{
+  collections::HashMap,
+  str::FromStr as _,
+  sync::Arc,
+};
+
+use tokio::sync::RwLock;
+use zbus::{
+  fdo,
+  interface,
+  object_server::SignalEmitter,
+  zvariant::Value,
+};
+
+use crate::{
+  profile::PowerProfile,
+  system::DaemonState,
+};
+
+const DRIVER_NAME: &str = "watt";
+const CPU_DRIVER_NAME: &str = "watt";
+
+pub struct PowerProfilesInterface {
+  state: Arc<RwLock<DaemonState>>,
+}
+
+impl PowerProfilesInterface {
+  pub fn new(state: Arc<RwLock<DaemonState>>) -> Self {
+    Self { state }
+  }
+}
+
+#[interface(name = "net.hadess.PowerProfiles")]
+impl PowerProfilesInterface {
+  // Properties
+  #[zbus(property)]
+  async fn active_profile(&self) -> String {
+    let state = self.state.read().await;
+    state.active_profile().as_str().to_owned()
+  }
+
+  #[zbus(property)]
+  async fn set_active_profile(&self, profile: &str) -> zbus::Result<()> {
+    let profile = match PowerProfile::from_str(profile) {
+      Ok(profile) => profile,
+      Err(_) => {
+        return Err(zbus::Error::from(fdo::Error::InvalidArgs(format!(
+          "invalid profile: {profile}, valid: performance, balanced, \
+           power-saver"
+        ))));
+      },
+    };
+
+    let mut state = self.state.write().await;
+    state.set_active_profile(profile);
+
+    log::info!(
+      "D-Bus: active profile set to {profile}",
+      profile = profile.as_str()
+    );
+
+    Ok(())
+  }
+
+  #[zbus(property)]
+  async fn profiles(&self) -> Vec<HashMap<String, Value<'_>>> {
+    PowerProfile::all()
+      .iter()
+      .map(|profile| {
+        let mut map = HashMap::new();
+        map.insert("Profile".to_owned(), Value::from(profile.as_str()));
+        map.insert("Driver".to_owned(), Value::from(DRIVER_NAME));
+        map.insert("CpuDriver".to_owned(), Value::from(CPU_DRIVER_NAME));
+        map
+      })
+      .collect()
+  }
+
+  #[zbus(property)]
+  async fn actions(&self) -> Vec<String> {
+    Vec::new()
+  }
+
+  #[zbus(property)]
+  async fn performance_degraded(&self) -> String {
+    let state = self.state.read().await;
+    state.performance_degraded().unwrap_or_default().to_owned()
+  }
+
+  #[zbus(property)]
+  async fn performance_inhibited(&self) -> String {
+    let state = self.state.read().await;
+    match state.profile_holds().first() {
+      Some(hold) => hold.reason.clone(),
+      None => String::new(),
+    }
+  }
+
+  #[zbus(property)]
+  async fn active_profile_holds(&self) -> Vec<HashMap<String, Value<'_>>> {
+    let state = self.state.read().await;
+    state
+      .profile_holds()
+      .into_iter()
+      .map(|hold| {
+        let mut map = HashMap::new();
+        map.insert("Profile".to_owned(), Value::from(hold.profile.as_str()));
+        map.insert("Reason".to_owned(), Value::from(hold.reason));
+        map
+          .insert("ApplicationId".to_owned(), Value::from(hold.application_id));
+        map
+      })
+      .collect()
+  }
+
+  async fn hold_profile(
+    &self,
+    #[zbus(signal_emitter)] signal_emitter: SignalEmitter<'_>,
+    profile: String,
+    reason: String,
+    application_id: String,
+  ) -> fdo::Result<u32> {
+    let profile = match PowerProfile::from_str(&profile) {
+      Ok(profile) => profile,
+      Err(_) => {
+        return Err(fdo::Error::InvalidArgs(format!(
+          "invalid profile: {profile}"
+        )));
+      },
+    };
+
+    if profile == PowerProfile::Balanced {
+      return Err(fdo::Error::InvalidArgs(
+        "profile holds only support performance and power-saver".to_owned(),
+      ));
+    }
+
+    let mut state = self.state.write().await;
+    let cookie = state.add_profile_hold(profile, reason, application_id);
+
+    log::info!("D-Bus profile hold added, cookie={cookie}");
+
+    // Emit property change signals
+    drop(state); // release lock before emitting signals
+
+    // Log signal failures but don't fail the operation.
+    // State was already mutated.
+    if let Err(e) = self.active_profile_holds_changed(&signal_emitter).await {
+      log::warn!("failed to emit ActiveProfileHolds change signal: {e}");
+    }
+
+    if let Err(e) = self.active_profile_changed(&signal_emitter).await {
+      log::warn!("failed to emit ActiveProfile change signal: {e}");
+    }
+
+    Ok(cookie)
+  }
+
+  async fn release_profile(
+    &self,
+    #[zbus(signal_emitter)] signal_emitter: SignalEmitter<'_>,
+    cookie: u32,
+  ) -> fdo::Result<()> {
+    let mut state = self.state.write().await;
+    state
+      .release_profile_hold(cookie)
+      .map_err(|error| fdo::Error::Failed(error.to_string()))?;
+
+    log::info!("D-Bus profile hold released, cookie={cookie}");
+
+    drop(state);
+
+    if let Err(e) = self.active_profile_holds_changed(&signal_emitter).await {
+      log::warn!("Failed to emit ActiveProfileHolds change signal: {e}");
+    }
+
+    if let Err(e) = self.active_profile_changed(&signal_emitter).await {
+      log::warn!("Failed to emit ActiveProfile change signal: {e}");
+    }
+
+    Ok(())
+  }
+}

--- a/watt/dbus/server.rs
+++ b/watt/dbus/server.rs
@@ -1,0 +1,57 @@
+use std::{
+  future,
+  sync::Arc,
+  time::Duration,
+};
+
+use tokio::sync::RwLock;
+use zbus::connection;
+
+use crate::system::DaemonState;
+
+pub async fn start(state: Arc<RwLock<DaemonState>>) -> zbus::Result<()> {
+  log::info!("starting D-Bus server...");
+
+  let mut attempt: u32 = 0;
+  loop {
+    match try_start(state.clone()).await {
+      Ok(()) => return Ok(()),
+      Err(e) => {
+        attempt += 1;
+        log::error!("D-Bus server error on attempt {attempt}: {e}");
+
+        if attempt >= 5 {
+          log::error!("D-Bus server failed after {attempt} attempts, bailing");
+          return Err(e);
+        }
+
+        let delay = Duration::from_secs(2 * attempt as u64);
+        log::info!(
+          "retrying D-Bus in {delay_secs}s",
+          delay_secs = delay.as_secs()
+        );
+        tokio::time::sleep(delay).await;
+      },
+    }
+  }
+}
+
+async fn try_start(state: Arc<RwLock<DaemonState>>) -> zbus::Result<()> {
+  let ppd = crate::dbus::ppd::PowerProfilesInterface::new(state.clone());
+  let watt = crate::dbus::watt::WattInterface::new(state);
+
+  let _connection = connection::Builder::system()?
+    .name("net.hadess.PowerProfiles")?
+    .name("dev.notashelf.Watt")?
+    .serve_at("/net/hadess/PowerProfiles", ppd)?
+    .serve_at("/dev/notashelf/Watt", watt)?
+    .build()
+    .await?;
+
+  log::info!("D-Bus server started");
+
+  // Block forever to keep the D-Bus server alive
+  loop {
+    future::pending::<()>().await;
+  }
+}

--- a/watt/dbus/watt.rs
+++ b/watt/dbus/watt.rs
@@ -1,0 +1,72 @@
+use std::{
+  collections::HashMap,
+  sync::Arc,
+};
+
+use tokio::sync::RwLock;
+use zbus::{
+  interface,
+  zvariant::Value,
+};
+
+use crate::system::DaemonState;
+
+pub struct WattInterface {
+  state: Arc<RwLock<DaemonState>>,
+}
+
+impl WattInterface {
+  pub fn new(state: Arc<RwLock<DaemonState>>) -> Self {
+    Self { state }
+  }
+}
+
+#[interface(name = "dev.notashelf.Watt")]
+impl WattInterface {
+  #[zbus(property)]
+  async fn version(&self) -> String {
+    env!("CARGO_PKG_VERSION").to_owned()
+  }
+
+  #[zbus(property)]
+  async fn rule_count(&self) -> u32 {
+    let state = self.state.read().await;
+    state.rule_count() as u32
+  }
+
+  #[zbus(property)]
+  async fn cpu_count(&self) -> u32 {
+    let state = self.state.read().await;
+    state.cpu_count() as u32
+  }
+
+  async fn get_status(&self) -> HashMap<String, Value<'_>> {
+    let state = self.state.read().await;
+    let mut status = HashMap::new();
+
+    if let Some(log) = state.latest_cpu_log() {
+      status.insert("cpu-usage".to_owned(), Value::from(log.usage * 100.0));
+
+      if let Some(temperature) = log.temperature {
+        status.insert("cpu-temperature".to_owned(), Value::from(temperature));
+      }
+    }
+
+    status.insert(
+      "profile".to_owned(),
+      Value::from(String::from(state.active_profile().as_str())),
+    );
+
+    status.insert(
+      "is-discharging".to_owned(),
+      Value::from(state.is_discharging()),
+    );
+
+    status
+  }
+
+  async fn get_applied_rules(&self) -> Vec<String> {
+    let state = self.state.read().await;
+    state.last_applied_rules()
+  }
+}

--- a/watt/profile.rs
+++ b/watt/profile.rs
@@ -1,0 +1,217 @@
+use std::{
+  collections::HashMap,
+  fmt,
+  str::FromStr,
+  time::Instant,
+};
+
+use serde::{
+  Deserialize,
+  Serialize,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PowerProfile {
+  Performance,
+  Balanced,
+  PowerSaver,
+}
+
+impl PowerProfile {
+  pub const fn as_str(self) -> &'static str {
+    match self {
+      Self::Performance => "performance",
+      Self::Balanced => "balanced",
+      Self::PowerSaver => "power-saver",
+    }
+  }
+
+  pub const fn all() -> [Self; 3] {
+    [Self::Performance, Self::Balanced, Self::PowerSaver]
+  }
+}
+
+impl fmt::Display for PowerProfile {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+impl FromStr for PowerProfile {
+  type Err = InvalidPowerProfile;
+
+  fn from_str(value: &str) -> Result<Self, Self::Err> {
+    match value {
+      "performance" => Ok(Self::Performance),
+      "balanced" => Ok(Self::Balanced),
+      "power-saver" => Ok(Self::PowerSaver),
+      _ => Err(InvalidPowerProfile),
+    }
+  }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct InvalidPowerProfile;
+
+impl fmt::Display for InvalidPowerProfile {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str("invalid power profile")
+  }
+}
+
+impl std::error::Error for InvalidPowerProfile {}
+
+#[derive(Debug, Clone)]
+pub struct ProfileHold {
+  pub cookie:         u32,
+  pub profile:        PowerProfile,
+  pub reason:         String,
+  pub application_id: String,
+  pub timestamp:      Instant,
+}
+
+#[derive(Debug)]
+pub struct ProfileState {
+  preferred_profile: PowerProfile,
+  holds:             HashMap<u32, ProfileHold>,
+  next_cookie:       u32,
+}
+
+impl ProfileState {
+  pub fn new() -> Self {
+    Self {
+      preferred_profile: PowerProfile::Balanced,
+      holds:             HashMap::new(),
+      next_cookie:       1,
+    }
+  }
+
+  pub fn add_hold(
+    &mut self,
+    profile: PowerProfile,
+    reason: String,
+    application_id: String,
+  ) -> u32 {
+    // Find an unused cookie, we'll want to handle wrap-around collision
+    let mut cookie = self.next_cookie;
+    while self.holds.contains_key(&cookie) {
+      cookie = cookie.wrapping_add(1);
+    }
+    self.next_cookie = cookie.wrapping_add(1);
+
+    let hold = ProfileHold {
+      cookie,
+      profile,
+      reason,
+      application_id,
+      timestamp: Instant::now(),
+    };
+
+    log::info!(
+      "profile hold added: cookie={cookie}, profile={profile:?}, app={app}",
+      app = hold.application_id,
+    );
+
+    self.holds.insert(cookie, hold);
+    cookie
+  }
+
+  pub fn release_hold(&mut self, cookie: u32) -> anyhow::Result<()> {
+    self
+      .holds
+      .remove(&cookie)
+      .ok_or_else(|| anyhow::anyhow!("hold with cookie {cookie} not found"))?;
+
+    log::info!("profile hold released: cookie={cookie}");
+    Ok(())
+  }
+
+  pub fn set_preference(&mut self, profile: PowerProfile) {
+    if self.preferred_profile != profile {
+      log::info!(
+        "profile preference changed: {old:?} -> {new:?}",
+        old = self.preferred_profile,
+        new = profile,
+      );
+      self.preferred_profile = profile;
+    }
+
+    if !self.holds.is_empty() {
+      log::info!(
+        "clearing {count} profile holds after manual profile change",
+        count = self.holds.len(),
+      );
+      self.holds.clear();
+    }
+  }
+
+  pub fn get_preference(&self) -> PowerProfile {
+    self.preferred_profile
+  }
+
+  pub fn get_effective_profile(&self) -> PowerProfile {
+    for profile in [
+      PowerProfile::PowerSaver,
+      PowerProfile::Performance,
+      PowerProfile::Balanced,
+    ] {
+      if self.holds.values().any(|hold| hold.profile == profile) {
+        return profile;
+      }
+    }
+
+    self.preferred_profile
+  }
+
+  pub fn get_holds(&self) -> Vec<ProfileHold> {
+    self.holds.values().cloned().collect()
+  }
+}
+
+impl Default for ProfileState {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{
+    PowerProfile,
+    ProfileState,
+  };
+
+  #[test]
+  fn profile_holds_prefer_power_saver_over_performance() {
+    let mut state = ProfileState::new();
+
+    state.add_hold(
+      PowerProfile::Performance,
+      "high-performance task".to_owned(),
+      "test.performance".to_owned(),
+    );
+    state.add_hold(
+      PowerProfile::PowerSaver,
+      "low battery".to_owned(),
+      "test.power-saver".to_owned(),
+    );
+
+    assert_eq!(state.get_effective_profile(), PowerProfile::PowerSaver);
+  }
+
+  #[test]
+  fn manual_profile_change_clears_holds() {
+    let mut state = ProfileState::new();
+
+    state.add_hold(
+      PowerProfile::Performance,
+      "high-performance task".to_owned(),
+      "test.performance".to_owned(),
+    );
+    state.set_preference(PowerProfile::Balanced);
+
+    assert_eq!(state.get_effective_profile(), PowerProfile::Balanced);
+    assert!(state.get_holds().is_empty());
+  }
+}

--- a/watt/system.rs
+++ b/watt/system.rs
@@ -6,14 +6,7 @@ use std::{
   },
   mem,
   path::Path,
-  sync::{
-    Arc,
-    atomic::{
-      AtomicBool,
-      Ordering,
-    },
-  },
-  thread,
+  sync::Arc,
   time::{
     Duration,
     Instant,
@@ -24,12 +17,17 @@ use anyhow::{
   Context,
   bail,
 };
+use tokio::{
+  signal,
+  sync::RwLock,
+};
 
 use crate::{
   config,
   cpu,
   fs,
   power_supply,
+  profile,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -53,7 +51,7 @@ struct CpuVolatility {
   temperature: Option<f64>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct PowerSupplyLog {
   at: Instant,
 
@@ -61,7 +59,7 @@ struct PowerSupplyLog {
   charge: f64,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 struct System {
   is_ac: bool,
 
@@ -828,32 +826,185 @@ fn idle_multiplier(idle_for: Duration) -> f64 {
   (1.0 + factor).clamp(1.0, 5.0)
 }
 
-pub fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
-  assert!(config.rules.is_sorted_by_key(|rule| rule.priority));
+fn compute_poll_delay(
+  system: &System,
+  last_polling_delay: Option<Duration>,
+  last_user_activity: Instant,
+) -> Duration {
+  let mut delay = Duration::from_secs(5);
+
+  if system.is_discharging() {
+    match system.power_supply_discharge_rate() {
+      Some(discharge_rate) if discharge_rate > 0.2 => delay *= 3,
+      Some(discharge_rate) if discharge_rate > 0.1 => delay *= 2,
+      Some(_) => {
+        delay /= 2;
+        delay *= 3;
+      },
+      None => delay *= 2,
+    }
+  }
+
+  if system.is_cpu_idle() {
+    let idle_for = last_user_activity.elapsed();
+
+    if idle_for > Duration::from_secs(30) {
+      let factor = idle_multiplier(idle_for);
+
+      log::debug!(
+        "system has been idle for {seconds} seconds (approx {minutes} \
+         minutes), applying idle factor: {factor:.2}x",
+        seconds = idle_for.as_secs(),
+        minutes = idle_for.as_secs() / 60,
+      );
+
+      delay = Duration::from_secs_f64(delay.as_secs_f64() * factor);
+    }
+  }
+
+  if let Some(volatility) = system.cpu_volatility()
+    && (volatility.usage > 0.1
+      || volatility
+        .temperature
+        .is_some_and(|temperature| temperature > 0.02))
+  {
+    delay = (delay / 2).max(Duration::from_secs(1));
+  }
+
+  let delay = match last_polling_delay {
+    Some(last_delay) => {
+      Duration::from_secs_f64(
+        delay.as_secs_f64() * 0.3 + last_delay.as_secs_f64() * 0.7,
+      )
+    },
+    None => delay,
+  };
+
+  Duration::from_secs_f64(delay.as_secs_f64().clamp(1.0, 30.0))
+}
+
+fn detect_performance_degradation(_system: &System) -> Option<String> {
+  None
+}
+
+#[derive(Debug)]
+pub struct DaemonState {
+  system:               System,
+  rule_count:           usize,
+  profile:              profile::ProfileState,
+  last_applied_rules:   Vec<String>,
+  performance_degraded: Option<String>,
+}
+
+impl DaemonState {
+  fn new(rule_count: usize) -> Self {
+    Self {
+      system: System::default(),
+      rule_count,
+      profile: profile::ProfileState::new(),
+      last_applied_rules: Vec::new(),
+      performance_degraded: None,
+    }
+  }
+
+  fn update_system(
+    &mut self,
+    system: &System,
+    last_applied_rules: Vec<String>,
+    performance_degraded: Option<String>,
+  ) {
+    self.system = system.clone();
+    self.last_applied_rules = last_applied_rules;
+    self.performance_degraded = performance_degraded;
+  }
+
+  pub fn active_profile(&self) -> profile::PowerProfile {
+    self.profile.get_effective_profile()
+  }
+
+  pub fn set_active_profile(&mut self, profile: profile::PowerProfile) {
+    self.profile.set_preference(profile);
+  }
+
+  pub fn profile_holds(&self) -> Vec<profile::ProfileHold> {
+    self.profile.get_holds()
+  }
+
+  pub fn add_profile_hold(
+    &mut self,
+    profile: profile::PowerProfile,
+    reason: String,
+    application_id: String,
+  ) -> u32 {
+    self.profile.add_hold(profile, reason, application_id)
+  }
+
+  pub fn release_profile_hold(&mut self, cookie: u32) -> anyhow::Result<()> {
+    self.profile.release_hold(cookie)
+  }
+
+  pub fn rule_count(&self) -> usize {
+    self.rule_count
+  }
+
+  pub fn cpu_count(&self) -> usize {
+    self.system.cpus.len()
+  }
+
+  pub fn latest_cpu_log(&self) -> Option<CpuLog> {
+    self.system.cpu_log.back().cloned()
+  }
+
+  pub fn is_discharging(&self) -> bool {
+    self.system.is_discharging()
+  }
+
+  pub fn performance_degraded(&self) -> Option<&str> {
+    self.performance_degraded.as_deref()
+  }
+
+  pub fn last_applied_rules(&self) -> Vec<String> {
+    self.last_applied_rules.clone()
+  }
+}
+
+pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
+  if !config.rules.is_sorted_by_key(|rule| rule.priority) {
+    bail!("daemon config rules must be sorted by priority");
+  }
 
   log::info!("starting daemon...");
 
-  let cancelled = Arc::new(AtomicBool::new(false));
+  let state = Arc::new(RwLock::new(DaemonState::new(config.rules.len())));
 
-  {
-    log::debug!("setting ctrl-c handler...");
-    ctrlc::set_handler({
-      let cancelled = Arc::clone(&cancelled);
-
-      move || {
-        log::info!("received shutdown signal");
-        cancelled.store(true, Ordering::SeqCst);
+  tokio::spawn({
+    let state = Arc::clone(&state);
+    async move {
+      if let Err(error) = crate::dbus::server::start(state).await {
+        log::error!("D-Bus server exited with error: {error}");
       }
-    })
-    .context("failed to set ctrl-c handler")?;
-  }
+    }
+  });
 
-  let mut system = System::default();
   let mut last_polling_delay = None::<Duration>;
   let mut last_user_activity = Instant::now();
+  let mut system = System::default();
+  let shutdown_signal = signal::ctrl_c();
+  tokio::pin!(shutdown_signal);
+  let mut sleep_for = Duration::ZERO;
 
-  while !cancelled.load(Ordering::SeqCst) {
+  loop {
+    tokio::select! {
+      result = &mut shutdown_signal => {
+        result.context("failed to listen for shutdown signal")?;
+        log::info!("received shutdown signal");
+        break;
+      },
+      () = tokio::time::sleep(sleep_for) => {},
+    }
+
     log::debug!("starting main polling loop iteration");
+    let start = Instant::now();
 
     system.scan()?;
 
@@ -861,244 +1012,180 @@ pub fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
       last_user_activity = Instant::now();
     }
 
+    let power_profile_preference = state.read().await.active_profile();
+    let performance_degraded = detect_performance_degradation(&system);
+
     let delay = {
-      let mut delay = Duration::from_secs(5);
+      let eval_state = config::EvalState {
+        frequency_available: system
+          .cpus
+          .iter()
+          .any(|cpu| cpu.frequency_mhz.is_some()),
+        turbo_available: cpu::Cpu::turbo()
+          .context(
+            "failed to read CPU turbo boost status for `is-turbo-available`",
+          )?
+          .is_some(),
 
-      // We are on battery, so we must be more conservative with our polling.
-      if system.is_discharging() {
-        match system.power_supply_discharge_rate() {
-          Some(discharge_rate) => {
-            if discharge_rate > 0.2 {
-              delay *= 3;
-            } else if discharge_rate > 0.1 {
-              delay *= 2;
-            } else {
-              // *= 1.5;
-              delay /= 2;
-              delay *= 3;
-            }
-          },
+        cpu_usage: system.cpu_log.back().context("CPU log is empty")?.usage,
+        cpu_usage_volatility: system.cpu_volatility().map(|vol| vol.usage),
+        cpu_temperature: system.cpu_log.back().and_then(|log| log.temperature),
+        cpu_temperature_volatility: system
+          .cpu_volatility()
+          .and_then(|vol| vol.temperature),
+        cpu_idle_seconds: last_user_activity.elapsed().as_secs_f64(),
+        cpu_frequency_maximum: cpu::Cpu::hardware_frequency_mhz_maximum()
+          .context("failed to read CPU hardware maximum frequency")?
+          .map(|u64| u64 as f64),
+        cpu_frequency_minimum: cpu::Cpu::hardware_frequency_mhz_minimum()
+          .context("failed to read CPU hardware minimum frequency")?
+          .map(|u64| u64 as f64),
 
-          // If we can't determine the discharge rate, that means that
-          // we were very recently started. Which is user activity.
-          None => {
-            delay *= 2;
-          },
-        }
-      }
+        lid_closed: system.lid_closed,
 
-      if system.is_cpu_idle() {
-        let idle_for = last_user_activity.elapsed();
+        power_supply_charge: system
+          .power_supply_log
+          .back()
+          .map(|log| log.charge),
+        power_supply_discharge_rate: system.power_supply_discharge_rate(),
 
-        if idle_for > Duration::from_secs(30) {
-          let factor = idle_multiplier(idle_for);
+        battery_cycles: system.battery_cycles,
+        battery_health: system.battery_health,
 
-          log::debug!(
-            "system has been idle for {seconds} seconds (approx {minutes} \
-             minutes), applying idle factor: {factor:.2}x",
-            seconds = idle_for.as_secs(),
-            minutes = idle_for.as_secs() / 60,
-          );
+        discharging: system.is_discharging(),
+        power_profile_preference,
 
-          delay = Duration::from_secs_f64(delay.as_secs_f64() * factor);
-        }
-      }
+        context: config::EvalContext::WidestPossible,
 
-      if let Some(volatility) = system.cpu_volatility()
-        && (volatility.usage > 0.1
-          || volatility.temperature.is_some_and(|t| t > 0.02))
-      {
-        delay = (delay / 2).max(Duration::from_secs(1));
-      }
-
-      let delay = match last_polling_delay {
-        Some(last_delay) => {
-          Duration::from_secs_f64(
-            // 30% of current computed delay, 70% of last delay.
-            delay.as_secs_f64() * 0.3 + last_delay.as_secs_f64() * 0.7,
-          )
-        },
-
-        None => delay,
+        cpus: &system.cpus,
+        power_supplies: &system.power_supplies,
+        cpu_log: &system.cpu_log,
       };
 
-      let delay = Duration::from_secs_f64(delay.as_secs_f64().clamp(1.0, 30.0));
-
-      last_polling_delay = Some(delay);
-
-      delay
-    };
-    log::info!(
-      "next poll will be in {seconds} seconds or {minutes} minutes, possibly \
-       delayed if application of rules takes more than the polling delay",
-      seconds = delay.as_secs_f64(),
-      minutes = delay.as_secs_f64() / 60.0,
-    );
-
-    log::info!("filtering rules and applying them...");
-
-    let start = Instant::now();
-
-    let state = config::EvalState {
-      frequency_available: system
+      let mut cpu_deltas: HashMap<Arc<cpu::Cpu>, cpu::Delta> = system
         .cpus
         .iter()
-        .any(|cpu| cpu.frequency_mhz.is_some()),
-      turbo_available:     cpu::Cpu::turbo()
-        .context(
-          "failed to read CPU turbo boost status for `is-turbo-available`",
-        )?
-        .is_some(),
+        .map(|cpu| (Arc::clone(cpu), cpu::Delta::default()))
+        .collect();
+      let mut cpu_turbo: Option<bool> = None;
 
-      cpu_usage:                  system
-        .cpu_log
-        .back()
-        .context("CPU log is empty")?
-        .usage,
-      cpu_usage_volatility:       system.cpu_volatility().map(|vol| vol.usage),
-      cpu_temperature:            system
-        .cpu_log
-        .back()
-        .and_then(|log| log.temperature),
-      cpu_temperature_volatility: system
-        .cpu_volatility()
-        .and_then(|vol| vol.temperature),
-      cpu_idle_seconds:           last_user_activity.elapsed().as_secs_f64(),
-      cpu_frequency_maximum:      cpu::Cpu::hardware_frequency_mhz_maximum()
-        .context("failed to read CPU hardware maximum frequency")?
-        .map(|u64| u64 as f64),
-      cpu_frequency_minimum:      cpu::Cpu::hardware_frequency_mhz_minimum()
-        .context("failed to read CPU hardware minimum frequency")?
-        .map(|u64| u64 as f64),
+      let mut power_deltas: HashMap<
+        Arc<power_supply::PowerSupply>,
+        power_supply::Delta,
+      > = system
+        .power_supplies
+        .iter()
+        .map(|power_supply| {
+          (Arc::clone(power_supply), power_supply::Delta::default())
+        })
+        .collect();
+      let mut power_platform_profile: Option<String> = None;
 
-      lid_closed: system.lid_closed,
+      // Higher priority rule first, so we can short-circuit.
+      let mut last_applied_rules = Vec::new();
 
-      power_supply_charge:         system
-        .power_supply_log
-        .back()
-        .map(|log| log.charge),
-      power_supply_discharge_rate: system.power_supply_discharge_rate(),
-
-      battery_cycles: system.battery_cycles,
-      battery_health: system.battery_health,
-
-      discharging: system.is_discharging(),
-
-      context: config::EvalContext::WidestPossible,
-
-      cpus:           &system.cpus,
-      power_supplies: &system.power_supplies,
-      cpu_log:        &system.cpu_log,
-    };
-
-    let mut cpu_deltas: HashMap<Arc<cpu::Cpu>, cpu::Delta> = system
-      .cpus
-      .iter()
-      .map(|cpu| (Arc::clone(cpu), cpu::Delta::default()))
-      .collect();
-    let mut cpu_turbo: Option<bool> = None;
-
-    let mut power_deltas: HashMap<
-      Arc<power_supply::PowerSupply>,
-      power_supply::Delta,
-    > = system
-      .power_supplies
-      .iter()
-      .map(|power_supply| {
-        (Arc::clone(power_supply), power_supply::Delta::default())
-      })
-      .collect();
-    let mut power_platform_profile: Option<String> = None;
-
-    // Higher priority rule first, so we can short-circuit.
-    for rule in config.rules.iter().rev() {
-      let Some(condition) = rule.condition.eval(&state)? else {
-        continue;
-      };
-
-      let condition = condition
-        .try_into_boolean()
-        .context("`if` was not a boolean")?;
-
-      if condition {
-        log::info!(
-          "rule '{name}' condition evaluated to true! evaluating members...",
-          name = rule.name,
-        );
-
-        let cpu_some = {
-          let (cpu_deltas_lo, cpu_turbo_lo) = rule.cpu.eval(&state)?;
-
-          for (cpu, delta) in cpu_deltas.iter_mut() {
-            let delta_lo = cpu_deltas_lo
-              .get(cpu)
-              .expect("cpu deltas and cpus should match");
-
-            *delta = mem::take(delta).or(delta_lo);
-          }
-
-          cpu_turbo = cpu_turbo.or(cpu_turbo_lo);
-
-          let deltas_some = cpu_deltas.values().all(|delta| delta.is_some());
-          deltas_some && cpu_turbo.is_some()
+      for rule in config.rules.iter().rev() {
+        let Some(condition) = rule.condition.eval(&eval_state)? else {
+          continue;
         };
 
-        let power_some = {
-          let (power_deltas_lo, power_platform_profile_lo) =
-            rule.power.eval(&state)?;
+        let condition = condition
+          .try_into_boolean()
+          .context("`if` was not a boolean")?;
 
-          for (power, delta) in power_deltas.iter_mut() {
-            let delta_lo = power_deltas_lo
-              .get(power)
-              .expect("power deltas and power supplies should match");
-
-            *delta = mem::take(delta).or(delta_lo);
-          }
-
-          power_platform_profile =
-            power_platform_profile.or(power_platform_profile_lo);
-
-          let deltas_some = power_deltas.values().all(|delta| delta.is_some());
-          deltas_some && power_platform_profile.is_some()
-        };
-
-        if cpu_some && power_some {
-          log::debug!(
-            "got a full delta from rules, short circuting evaluation"
+        if condition {
+          log::info!(
+            "rule '{name}' condition evaluated to true! evaluating members...",
+            name = rule.name,
           );
-          break;
+
+          last_applied_rules.push(rule.name.clone());
+
+          let cpu_some = {
+            let (cpu_deltas_lo, cpu_turbo_lo) = rule.cpu.eval(&eval_state)?;
+
+            for (cpu, delta) in cpu_deltas.iter_mut() {
+              let delta_lo = cpu_deltas_lo
+                .get(cpu)
+                .expect("cpu deltas and cpus should match");
+
+              *delta = mem::take(delta).or(delta_lo);
+            }
+
+            cpu_turbo = cpu_turbo.or(cpu_turbo_lo);
+
+            let deltas_some = cpu_deltas.values().all(|delta| delta.is_some());
+            deltas_some && cpu_turbo.is_some()
+          };
+
+          let power_some = {
+            let (power_deltas_lo, power_platform_profile_lo) =
+              rule.power.eval(&eval_state)?;
+
+            for (power, delta) in power_deltas.iter_mut() {
+              let delta_lo = power_deltas_lo
+                .get(power)
+                .expect("power deltas and power supplies should match");
+
+              *delta = mem::take(delta).or(delta_lo);
+            }
+
+            power_platform_profile =
+              power_platform_profile.or(power_platform_profile_lo);
+
+            let deltas_some =
+              power_deltas.values().all(|delta| delta.is_some());
+            deltas_some && power_platform_profile.is_some()
+          };
+
+          if cpu_some && power_some {
+            log::debug!(
+              "got a full delta from rules, short circuting evaluation"
+            );
+            break;
+          }
         }
       }
-    }
 
-    for (cpu, delta) in &cpu_deltas {
-      delta
-        .apply(&mut (**cpu).clone())
-        .with_context(|| format!("failed to apply delta to {cpu}"))?;
-    }
+      for (cpu, delta) in &cpu_deltas {
+        delta
+          .apply(&mut (**cpu).clone())
+          .with_context(|| format!("failed to apply delta to {cpu}"))?;
+      }
 
-    log::info!("applying CPU deltas to {len} CPUs", len = cpu_deltas.len());
+      log::info!("applying CPU deltas to {len} CPUs", len = cpu_deltas.len());
 
-    if let Some(turbo) = cpu_turbo {
-      cpu::Cpu::set_turbo(turbo, cpu_deltas.keys().map(|arc| &**arc))
-        .context("failed to set CPU turbo")?;
-    }
+      if let Some(turbo) = cpu_turbo {
+        cpu::Cpu::set_turbo(turbo, cpu_deltas.keys().map(|arc| &**arc))
+          .context("failed to set CPU turbo")?;
+      }
 
-    log::info!(
-      "applying power supply deltas to {len} devices",
-      len = power_deltas.len(),
-    );
+      log::info!(
+        "applying power supply deltas to {len} devices",
+        len = power_deltas.len(),
+      );
 
-    for (power, delta) in power_deltas {
-      delta
-        .apply(&mut (*power).clone())
-        .with_context(|| format!("failed to apply delta to {power}"))?;
-    }
+      for (power, delta) in power_deltas {
+        delta
+          .apply(&mut (*power).clone())
+          .with_context(|| format!("failed to apply delta to {power}"))?;
+      }
 
-    if let Some(platform_profile) = power_platform_profile {
-      power_supply::PowerSupply::set_platform_profile(&platform_profile)
-        .context("failed to set power supply platform profile")?;
-    }
+      if let Some(platform_profile) = power_platform_profile {
+        power_supply::PowerSupply::set_platform_profile(&platform_profile)
+          .context("failed to set power supply platform profile")?;
+      }
+
+      let delay =
+        compute_poll_delay(&system, last_polling_delay, last_user_activity);
+      state.write().await.update_system(
+        &system,
+        last_applied_rules,
+        performance_degraded,
+      );
+      last_polling_delay = Some(delay);
+      delay
+    };
 
     let elapsed = start.elapsed();
     log::info!(
@@ -1107,10 +1194,17 @@ pub fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
       minutes = elapsed.as_secs_f64() / 60.0,
     );
 
-    thread::sleep(delay.saturating_sub(elapsed));
+    log::info!(
+      "next poll will be in {seconds} seconds or {minutes} minutes, possibly \
+       delayed if application of rules takes more than the polling delay",
+      seconds = delay.as_secs_f64(),
+      minutes = delay.as_secs_f64() / 60.0,
+    );
+
+    sleep_for = delay.saturating_sub(elapsed);
   }
 
-  log::info!("stopping polling loop and thus ..");
+  log::info!("stopping polling loop and shutting down");
 
   Ok(())
 }


### PR DESCRIPTION
Introduces D-Bus support to Watt, which enables external control and monitoring of power profiles and system status as discussed with @RGBCube. This PR implements D-Bus interfaces for power profile management and status reporting, and a new `PowerProfile` system with preference and hold logic. 

Rough draft right now, and is lacking a CLI interface---which is the main thing I care about.