### PR TITLE
cpu: calculate current CPU usage from delta instead of avg since boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +763,7 @@ dependencies = [
  "clap-verbosity-flag",
  "ctrlc",
  "env_logger",
+ "humantime",
  "log",
  "nix 0.31.1",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ env_logger            = "0.11.8"
 log                   = "0.4.28"
 nix                   = { features = [ "fs" ], version = "0.31.1" }
 num_cpus              = "1.17.0"
+humantime             = "2.3.0"
 serde                 = { features = [ "derive" ], version = "1.0.228" }
 toml                  = "0.9.8"
 yansi                 = { features = [ "detect-env", "detect-tty" ], version = "1.0.1" }

--- a/watt/Cargo.toml
+++ b/watt/Cargo.toml
@@ -19,6 +19,7 @@ clap.workspace                = true
 clap-verbosity-flag.workspace = true
 ctrlc.workspace               = true
 env_logger.workspace          = true
+humantime.workspace           = true
 log.workspace                 = true
 nix.workspace                 = true
 num_cpus.workspace            = true

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -1056,6 +1056,7 @@ mod tests {
         available_epbs: vec![],
         epb: None,
         stat: cpu::CpuStat::default(),
+        previous_stat: None,
         info: None,
       });
 
@@ -1143,6 +1144,7 @@ mod tests {
       available_epbs:        vec![],
       epb:                   None,
       stat:                  cpu::CpuStat::default(),
+      previous_stat:         None,
       info:                  None,
     });
 

--- a/watt/power_supply.rs
+++ b/watt/power_supply.rs
@@ -197,7 +197,11 @@ impl PowerSupply {
     self.is_from_peripheral = 'is_from_peripheral: {
       let name_lower = self.name.to_lowercase();
 
-      log::trace!("power supply '{name}' type: {type_}", name = self.name, type_ = self.type_);
+      log::trace!(
+        "power supply '{name}' type: {type_}",
+        name = self.name,
+        type_ = self.type_
+      );
 
       // Common peripheral battery names.
       if name_lower.contains("mouse")

--- a/watt/system.rs
+++ b/watt/system.rs
@@ -32,15 +32,15 @@ use crate::{
   power_supply,
 };
 
-#[derive(Debug)]
-struct CpuLog {
-  at: Instant,
+#[derive(Debug, Clone, PartialEq)]
+pub struct CpuLog {
+  pub at: Instant,
 
   /// CPU usage between 0-1, a percentage.
-  usage: f64,
+  pub usage: f64,
 
   /// CPU temperature in celsius.
-  temperature: f64,
+  pub temperature: f64,
 }
 
 #[derive(Debug)]
@@ -84,10 +84,22 @@ impl System {
 
     {
       let start = Instant::now();
+
+      // Preserve previous stats for delta calculation
+      let previous_stats: std::collections::HashMap<u32, cpu::CpuStat> = self
+        .cpus
+        .iter()
+        .map(|cpu| (cpu.number, cpu.stat.clone()))
+        .collect();
+
       self.cpus = cpu::Cpu::all()
         .context("failed to scan CPUs")?
         .into_iter()
-        .map(Arc::from)
+        .map(|mut cpu| {
+          // Transfer previous stat for this CPU
+          cpu.previous_stat = previous_stats.get(&cpu.number).cloned();
+          Arc::from(cpu)
+        })
         .collect();
       log::info!(
         "scanned all CPUs in {millis}ms",
@@ -167,7 +179,7 @@ impl System {
     let cpu_log = CpuLog {
       at,
 
-      usage: self.cpus.iter().map(|cpu| cpu.stat.usage()).sum::<f64>()
+      usage: self.cpus.iter().map(|cpu| cpu.current_usage()).sum::<f64>()
         / self.cpus.len() as f64,
 
       temperature: self.cpu_temperatures.values().sum::<f64>()
@@ -798,6 +810,7 @@ pub fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
 
       cpus:           &system.cpus,
       power_supplies: &system.power_supplies,
+      cpu_log:        &system.cpu_log,
     };
 
     let mut cpu_deltas: HashMap<Arc<cpu::Cpu>, cpu::Delta> = system

--- a/watt/system.rs
+++ b/watt/system.rs
@@ -86,7 +86,7 @@ impl System {
       let start = Instant::now();
 
       // Preserve previous stats for delta calculation
-      let previous_stats: std::collections::HashMap<u32, cpu::CpuStat> = self
+      let previous_stats: HashMap<u32, cpu::CpuStat> = self
         .cpus
         .iter()
         .map(|cpu| (cpu.number, cpu.stat.clone()))


### PR DESCRIPTION
Fixes #51, at least partially. Did not yet implement time-delta measurements yet, but it is not exactly a part of the issue I was trying to fix. Will be implementing at a later date alongside a `--dry-run` flag. 

This PR only introduces a new expression (`cpu-usage-since`) for evaluating CPU usage over a specified time interval and refactors CPU usage calculation to be based on recent usage deltas rather than historical averages. The time expression is backed by the humantime crate, which allows for intuitive time formats. Also adds support for logging CPU usage history.

Signed-off-by: NotAShelf <raf@notashelf.dev>
Change-Id: I2088217f2c2924fa9200f43033bb92426a6a6964