### PR TITLE
various: deprecate `%cpu-usage`; add new variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -90,9 +90,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block2"
@@ -186,9 +186,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "ctrlc"
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags",
  "block2",
@@ -254,15 +254,21 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
@@ -272,15 +278,37 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.16.1"
+name = "getrandom"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -301,13 +329,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
-name = "indexmap"
-version = "2.13.0"
+name = "id-arena"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -328,23 +364,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "jiff"
-version = "0.2.23"
+name = "itoa"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-sys",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -352,16 +396,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.185"
+name = "jiff-tzdb"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -371,9 +436,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nix"
@@ -408,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -423,9 +488,9 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -435,15 +500,15 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -458,6 +523,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -507,6 +582,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,7 +613,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -558,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -569,15 +650,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -597,6 +678,12 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -629,6 +716,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,12 +756,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -714,9 +814,15 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -735,11 +841,54 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -752,6 +901,7 @@ dependencies = [
  "ctrlc",
  "env_logger",
  "humantime",
+ "jiff",
  "log",
  "nix",
  "num_cpus",
@@ -787,6 +937,94 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "xtask"
@@ -809,20 +1047,26 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.35"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdea86ddd5568519879b8187e1cf04e24fce28f7fe046ceecbce472ff19a2572"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.35"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c15e1b46eff7c6c91195752e0eeed8ef040e391cdece7c25376957d5f15df22"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ clap_complete_nushell = "4.6.0"
 ctrlc                 = "3.5.2"
 env_logger            = "0.11.10"
 humantime             = "2.3.0"
+jiff                  = "0.2.24"
 log                   = "0.4.29"
 nix                   = { features = [ "fs" ], version = "0.31.2" }
 num_cpus              = "1.17.0"

--- a/README.md
+++ b/README.md
@@ -272,12 +272,20 @@ Watt includes a powerful expression language for defining conditions:
 - `"$cpu-frequency-minimum"` - CPU hardware minimum frequency in MHz
 - `"$cpu-scaling-maximum"` - Current CPU scaling maximum frequency in MHz (from
   `scaling_max_freq`)
-- `"$load-average-1m"` - System load average over the last 1 minute
-- `"$load-average-5m"` - System load average over the last 5 minutes
-- `"$load-average-15m"` - System load average over the last 15 minutes
+- `"%cpu-core-count"` - Number of CPU cores
+- `{ load-average-since = "<duration>" }` - System load average over a duration
+  (e.g., `"5sec"`, `"1min"`)
 - `"$hour-of-day"` - Current hour (0-23) based on system local time
+- `"?lid-closed"` - Boolean indicating if laptop lid is closed
 - `"%power-supply-charge"` - Battery charge percentage (0.0-1.0)
 - `"%power-supply-discharge-rate"` - Current discharge rate
+- `"%battery-cycles"` - Battery cycle count (aggregated average across all
+  batteries)
+- `"%battery-health"` - Battery health percentage (0.0-1.0, aggregated average
+  across all batteries)
+- `{ battery-cycles-for = "<name>" }` - Battery cycle count for a specific
+  battery (e.g., `"BAT0"`)
+- `{ battery-health-for = "<name>" }` - Battery health for a specific battery
 - `"?discharging"` - Boolean indicating if system is on battery power
 - `"?frequency-available"` - Boolean indicating if CPU frequency control is
   available
@@ -295,6 +303,7 @@ if.is-energy-performance-preference-available = "balance_performance"
 if.is-energy-perf-bias-available = "5"
 if.is-platform-profile-available = "low-power"
 if.is-driver-loaded = "intel_pstate"
+if.is-battery-available = "BAT0"
 ```
 
 Each will be `true` only if the named value is available on your system. If the

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ but Watt attempts to support multiple vendor implementations including:
 # High performance for sustained workloads with thermal protection
 [[rule]]
 if.all = [
-  { is-more-than = 0.8, value = "%cpu-usage" },
+  { is-more-than = 0.8, value = { cpu-usage-since = "2sec" } },
   { is-less-than = 30.0, value = "$cpu-idle-seconds" },
   { is-less-than = 75.0, value = "$cpu-temperature" },
 ]
@@ -262,7 +262,7 @@ Watt includes a powerful expression language for defining conditions:
 
 #### System Variables
 
-- `"%cpu-usage"` - Current CPU usage percentage (0.0-1.0)
+- `{ cpu-usage-since = "<duration>" }` - CPU usage percentage over a duration (e.g., `"1sec"`, `"5sec"`)
 - `"$cpu-usage-volatility"` - CPU usage volatility measurement
 - `"$cpu-temperature"` - CPU temperature in Celsius
 - `"$cpu-temperature-volatility"` - CPU temperature volatility
@@ -305,7 +305,7 @@ You can use operators with TOML attribute sets:
 
 ```toml
 [[rule]]
-if = { is-more-than = "%cpu-usage", value = 0.8 }
+if = { is-more-than = { cpu-usage-since = "1sec" }, value = 0.8 }
 ```
 
 However, `all` and `any` do not take a `value` argument, but instead take a list
@@ -359,7 +359,7 @@ power.platform-profile = { if.is-platform-profile-available = "low-power", then 
 # High performance mode for sustained high load
 [[rule]]
 if.all = [
-  { is-more-than = 0.8, value = "%cpu-usage" },
+  { is-more-than = 0.8, value = { cpu-usage-since = "2sec" } },
   { is-less-than = 30.0, value = "$cpu-idle-seconds" },
   { is-less-than = 75.0, value = "$cpu-temperature" },
 ]
@@ -374,7 +374,7 @@ cpu.turbo = { if = "?turbo-available", then = true }
 [[rule]]
 if.all = [
   { not = "?discharging" },
-  { is-more-than = 0.1, value = "%cpu-usage" },
+  { is-more-than = 0.1, value = { cpu-usage-since = "1sec" } },
   { is-less-than = 80.0, value = "$cpu-temperature" },
 ]
 priority = 70
@@ -387,8 +387,8 @@ cpu.turbo = { if = "?turbo-available", then = true }
 # Moderate performance for medium load
 [[rule]]
 if.all = [
-  { is-more-than = 0.4, value = "%cpu-usage" },
-  { is-less-than = 0.8, value = "%cpu-usage" },
+  { is-more-than = 0.4, value = { cpu-usage-since = "5sec" } },
+  { is-less-than = 0.8, value = { cpu-usage-since = "5sec" } },
 ]
 priority = 60
 
@@ -399,7 +399,7 @@ cpu.governor = { if.is-governor-available = "schedutil", then = "schedutil" }
 # Power saving during low activity
 [[rule]]
 if.all = [
-  { is-less-than = 0.2, value = "%cpu-usage" },
+  { is-less-than = 0.2, value = { cpu-usage-since = "10sec" } },
   { is-more-than = 60.0, value = "$cpu-idle-seconds" },
 ]
 priority = 50

--- a/README.md
+++ b/README.md
@@ -262,13 +262,19 @@ Watt includes a powerful expression language for defining conditions:
 
 #### System Variables
 
-- `{ cpu-usage-since = "<duration>" }` - CPU usage percentage over a duration (e.g., `"1sec"`, `"5sec"`)
+- `{ cpu-usage-since = "<duration>" }` - CPU usage percentage over a duration
+  (e.g., `"1sec"`, `"5sec"`)
 - `"$cpu-usage-volatility"` - CPU usage volatility measurement
 - `"$cpu-temperature"` - CPU temperature in Celsius
 - `"$cpu-temperature-volatility"` - CPU temperature volatility
 - `"$cpu-idle-seconds"` - Seconds since last significant CPU activity
 - `"$cpu-frequency-maximum"` - CPU hardware maximum frequency in MHz
 - `"$cpu-frequency-minimum"` - CPU hardware minimum frequency in MHz
+- `"$cpu-scaling-maximum"` - Current CPU scaling maximum frequency in MHz (from
+  `scaling_max_freq`)
+- `"$load-average-1m"` - System load average over the last 1 minute
+- `"$load-average-5m"` - System load average over the last 5 minutes
+- `"$load-average-15m"` - System load average over the last 15 minutes
 - `"%power-supply-charge"` - Battery charge percentage (0.0-1.0)
 - `"%power-supply-discharge-rate"` - Current discharge rate
 - `"?discharging"` - Boolean indicating if system is on battery power

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Watt includes a powerful expression language for defining conditions:
 - `"$load-average-1m"` - System load average over the last 1 minute
 - `"$load-average-5m"` - System load average over the last 5 minutes
 - `"$load-average-15m"` - System load average over the last 15 minutes
+- `"$hour-of-day"` - Current hour (0-23) based on system local time
 - `"%power-supply-charge"` - Battery charge percentage (0.0-1.0)
 - `"%power-supply-discharge-rate"` - Current discharge rate
 - `"?discharging"` - Boolean indicating if system is on battery power

--- a/watt/Cargo.toml
+++ b/watt/Cargo.toml
@@ -20,6 +20,7 @@ clap-verbosity-flag.workspace = true
 ctrlc.workspace               = true
 env_logger.workspace          = true
 humantime.workspace           = true
+jiff.workspace                = true
 log.workspace                 = true
 nix.workspace                 = true
 num_cpus.workspace            = true

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -662,10 +662,6 @@ pub struct EvalState<'peripherals, 'context> {
   pub cpu_frequency_maximum:      Option<f64>,
   pub cpu_frequency_minimum:      Option<f64>,
 
-  pub cpu_scaling_maximum: Option<f64>,
-
-  pub cpu_core_count: u32,
-
   pub load_average_1m:  f64,
   pub load_average_5m:  f64,
   pub load_average_15m: f64,
@@ -838,9 +834,17 @@ impl Expression {
       CpuFrequencyMaximum => Number(try_ok!(state.cpu_frequency_maximum)),
       CpuFrequencyMinimum => Number(try_ok!(state.cpu_frequency_minimum)),
 
-      CpuScalingMaximum => Number(try_ok!(state.cpu_scaling_maximum)),
+      CpuScalingMaximum => {
+        let max = state
+          .cpus
+          .iter()
+          .filter_map(|cpu| cpu.frequency_mhz_maximum)
+          .max()
+          .map(|v| v as f64);
+        Number(try_ok!(max))
+      },
 
-      CpuCoreCount => Number(state.cpu_core_count as f64),
+      CpuCoreCount => Number(state.cpus.len() as f64),
 
       LoadAverage1m => Number(state.load_average_1m),
       LoadAverage5m => Number(state.load_average_5m),
@@ -1156,8 +1160,6 @@ mod tests {
         cpu_idle_seconds: 10.0,
         cpu_frequency_maximum: Some(base_freq as f64),
         cpu_frequency_minimum: Some(1000.0),
-        cpu_scaling_maximum: Some(base_freq as f64),
-        cpu_core_count: 1,
         load_average_1m: 0.5,
         load_average_5m: 0.6,
         load_average_15m: 0.7,
@@ -1251,8 +1253,6 @@ mod tests {
       cpu_idle_seconds:            10.0,
       cpu_frequency_maximum:       Some(3333.0),
       cpu_frequency_minimum:       Some(1000.0),
-      cpu_scaling_maximum:         Some(3500.0),
-      cpu_core_count:              1,
       load_average_1m:             0.5,
       load_average_5m:             0.6,
       load_average_15m:            0.7,
@@ -1334,8 +1334,6 @@ mod tests {
       cpu_idle_seconds:            0.0,
       cpu_frequency_maximum:       Some(3333.0),
       cpu_frequency_minimum:       Some(1000.0),
-      cpu_scaling_maximum:         Some(3500.0),
-      cpu_core_count:              1,
       load_average_1m:             0.0,
       load_average_5m:             0.0,
       load_average_15m:            0.0,

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -390,6 +390,12 @@ mod expression {
   named!(cpu_frequency_maximum => "$cpu-frequency-maximum");
   named!(cpu_frequency_minimum => "$cpu-frequency-minimum");
 
+  named!(cpu_scaling_maximum => "$cpu-scaling-maximum");
+
+  named!(load_average_1m => "$load-average-1m");
+  named!(load_average_5m => "$load-average-5m");
+  named!(load_average_15m => "$load-average-15m");
+
   named!(power_supply_charge => "%power-supply-charge");
   named!(power_supply_discharge_rate => "%power-supply-discharge-rate");
 
@@ -452,6 +458,18 @@ pub enum Expression {
 
   #[serde(with = "expression::cpu_frequency_minimum")]
   CpuFrequencyMinimum,
+
+  #[serde(with = "expression::cpu_scaling_maximum")]
+  CpuScalingMaximum,
+
+  #[serde(with = "expression::load_average_1m")]
+  LoadAverage1m,
+
+  #[serde(with = "expression::load_average_5m")]
+  LoadAverage5m,
+
+  #[serde(with = "expression::load_average_15m")]
+  LoadAverage15m,
 
   #[serde(with = "expression::power_supply_charge")]
   PowerSupplyCharge,
@@ -620,6 +638,12 @@ pub struct EvalState<'peripherals, 'context> {
   pub cpu_frequency_maximum:      Option<f64>,
   pub cpu_frequency_minimum:      Option<f64>,
 
+  pub cpu_scaling_maximum: Option<f64>,
+
+  pub load_average_1m:  f64,
+  pub load_average_5m:  f64,
+  pub load_average_15m: f64,
+
   pub power_supply_charge:         Option<f64>,
   pub power_supply_discharge_rate: Option<f64>,
 
@@ -782,6 +806,12 @@ impl Expression {
       CpuIdleSeconds => Number(state.cpu_idle_seconds),
       CpuFrequencyMaximum => Number(try_ok!(state.cpu_frequency_maximum)),
       CpuFrequencyMinimum => Number(try_ok!(state.cpu_frequency_minimum)),
+
+      CpuScalingMaximum => Number(try_ok!(state.cpu_scaling_maximum)),
+
+      LoadAverage1m => Number(state.load_average_1m),
+      LoadAverage5m => Number(state.load_average_5m),
+      LoadAverage15m => Number(state.load_average_15m),
 
       PowerSupplyCharge => Number(try_ok!(state.power_supply_charge)),
       PowerSupplyDischargeRate => {
@@ -1081,6 +1111,10 @@ mod tests {
         cpu_idle_seconds: 10.0,
         cpu_frequency_maximum: Some(base_freq as f64),
         cpu_frequency_minimum: Some(1000.0),
+        cpu_scaling_maximum: Some(base_freq as f64),
+        load_average_1m: 0.5,
+        load_average_5m: 0.6,
+        load_average_15m: 0.7,
         power_supply_charge: Some(0.8),
         power_supply_discharge_rate: Some(10.0),
         discharging: false,
@@ -1168,6 +1202,10 @@ mod tests {
       cpu_idle_seconds:            10.0,
       cpu_frequency_maximum:       Some(3333.0),
       cpu_frequency_minimum:       Some(1000.0),
+      cpu_scaling_maximum:         Some(3500.0),
+      load_average_1m:             0.5,
+      load_average_5m:             0.6,
+      load_average_15m:            0.7,
       power_supply_charge:         Some(0.8),
       power_supply_discharge_rate: Some(10.0),
       discharging:                 false,
@@ -1243,6 +1281,10 @@ mod tests {
       cpu_idle_seconds:            0.0,
       cpu_frequency_maximum:       Some(3333.0),
       cpu_frequency_minimum:       Some(1000.0),
+      cpu_scaling_maximum:         Some(3500.0),
+      load_average_1m:             0.0,
+      load_average_5m:             0.0,
+      load_average_15m:            0.0,
       power_supply_charge:         None,
       power_supply_discharge_rate: None,
       discharging:                 false,

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -396,6 +396,8 @@ mod expression {
   named!(load_average_5m => "$load-average-5m");
   named!(load_average_15m => "$load-average-15m");
 
+  named!(hour_of_day => "$hour-of-day");
+
   named!(power_supply_charge => "%power-supply-charge");
   named!(power_supply_discharge_rate => "%power-supply-discharge-rate");
 
@@ -470,6 +472,9 @@ pub enum Expression {
 
   #[serde(with = "expression::load_average_15m")]
   LoadAverage15m,
+
+  #[serde(with = "expression::hour_of_day")]
+  HourOfDay,
 
   #[serde(with = "expression::power_supply_charge")]
   PowerSupplyCharge,
@@ -812,6 +817,13 @@ impl Expression {
       LoadAverage1m => Number(state.load_average_1m),
       LoadAverage5m => Number(state.load_average_5m),
       LoadAverage15m => Number(state.load_average_15m),
+
+      HourOfDay => {
+        let ts = jiff::Timestamp::now()
+          .in_tz("local")
+          .context("failed to get local timezone for `$hour-of-day`")?;
+        Number(ts.hour() as f64)
+      },
 
       PowerSupplyCharge => Number(try_ok!(state.power_supply_charge)),
       PowerSupplyDischargeRate => {

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -470,8 +470,8 @@ pub enum Expression {
   #[serde(with = "expression::cpu_core_count")]
   CpuCoreCount,
 
-  #[serde(rename = "load-average-since")]
   LoadAverageSince {
+    #[serde(rename = "load-average-since")]
     duration: String,
   },
 

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -746,7 +746,13 @@ impl Expression {
       FrequencyAvailable => Boolean(state.frequency_available),
       TurboAvailable => Boolean(state.turbo_available),
 
-      CpuUsage => Number(state.cpu_usage),
+      CpuUsage => {
+        bail!(
+          "`%cpu-usage` is deprecated and has been removed. Use \
+           `cpu-usage-since = \"<duration>\"` instead. For example, \
+           `cpu-usage-since = \"1sec\"` for CPU usage over the last second."
+        )
+      },
       CpuUsageSince { duration } => {
         let duration = humantime::parse_duration(duration)
           .with_context(|| format!("failed to parse duration '{duration}'"))?;

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -392,14 +392,21 @@ mod expression {
 
   named!(cpu_scaling_maximum => "$cpu-scaling-maximum");
 
+  named!(cpu_core_count => "%cpu-core-count");
+
   named!(load_average_1m => "$load-average-1m");
   named!(load_average_5m => "$load-average-5m");
   named!(load_average_15m => "$load-average-15m");
+
+  named!(lid_closed => "?lid-closed");
 
   named!(hour_of_day => "$hour-of-day");
 
   named!(power_supply_charge => "%power-supply-charge");
   named!(power_supply_discharge_rate => "%power-supply-discharge-rate");
+
+  named!(battery_cycles => "$battery-cycles");
+  named!(battery_health => "%battery-health");
 
   named!(discharging => "?discharging");
 }
@@ -464,6 +471,9 @@ pub enum Expression {
   #[serde(with = "expression::cpu_scaling_maximum")]
   CpuScalingMaximum,
 
+  #[serde(with = "expression::cpu_core_count")]
+  CpuCoreCount,
+
   #[serde(with = "expression::load_average_1m")]
   LoadAverage1m,
 
@@ -473,6 +483,9 @@ pub enum Expression {
   #[serde(with = "expression::load_average_15m")]
   LoadAverage15m,
 
+  #[serde(with = "expression::lid_closed")]
+  LidClosed,
+
   #[serde(with = "expression::hour_of_day")]
   HourOfDay,
 
@@ -481,6 +494,12 @@ pub enum Expression {
 
   #[serde(with = "expression::power_supply_discharge_rate")]
   PowerSupplyDischargeRate,
+
+  #[serde(with = "expression::battery_cycles")]
+  BatteryCycles,
+
+  #[serde(with = "expression::battery_health")]
+  BatteryHealth,
 
   #[serde(with = "expression::discharging")]
   Discharging,
@@ -645,12 +664,19 @@ pub struct EvalState<'peripherals, 'context> {
 
   pub cpu_scaling_maximum: Option<f64>,
 
+  pub cpu_core_count: u32,
+
   pub load_average_1m:  f64,
   pub load_average_5m:  f64,
   pub load_average_15m: f64,
 
+  pub lid_closed: bool,
+
   pub power_supply_charge:         Option<f64>,
   pub power_supply_discharge_rate: Option<f64>,
+
+  pub battery_cycles: Option<f64>,
+  pub battery_health: Option<f64>,
 
   pub discharging: bool,
 
@@ -814,9 +840,13 @@ impl Expression {
 
       CpuScalingMaximum => Number(try_ok!(state.cpu_scaling_maximum)),
 
+      CpuCoreCount => Number(state.cpu_core_count as f64),
+
       LoadAverage1m => Number(state.load_average_1m),
       LoadAverage5m => Number(state.load_average_5m),
       LoadAverage15m => Number(state.load_average_15m),
+
+      LidClosed => Boolean(state.lid_closed),
 
       HourOfDay => {
         let ts = jiff::Timestamp::now()
@@ -829,6 +859,9 @@ impl Expression {
       PowerSupplyDischargeRate => {
         Number(try_ok!(state.power_supply_discharge_rate))
       },
+
+      BatteryCycles => Number(try_ok!(state.battery_cycles)),
+      BatteryHealth => Number(try_ok!(state.battery_health)),
 
       Discharging => Boolean(state.discharging),
 
@@ -1124,11 +1157,15 @@ mod tests {
         cpu_frequency_maximum: Some(base_freq as f64),
         cpu_frequency_minimum: Some(1000.0),
         cpu_scaling_maximum: Some(base_freq as f64),
+        cpu_core_count: 1,
         load_average_1m: 0.5,
         load_average_5m: 0.6,
         load_average_15m: 0.7,
+        lid_closed: false,
         power_supply_charge: Some(0.8),
         power_supply_discharge_rate: Some(10.0),
+        battery_cycles: Some(100.0),
+        battery_health: Some(0.95),
         discharging: false,
         context: EvalContext::Cpu(&cpu),
         cpus: &cpus,
@@ -1215,11 +1252,15 @@ mod tests {
       cpu_frequency_maximum:       Some(3333.0),
       cpu_frequency_minimum:       Some(1000.0),
       cpu_scaling_maximum:         Some(3500.0),
+      cpu_core_count:              1,
       load_average_1m:             0.5,
       load_average_5m:             0.6,
       load_average_15m:            0.7,
+      lid_closed:                  false,
       power_supply_charge:         Some(0.8),
       power_supply_discharge_rate: Some(10.0),
+      battery_cycles:              Some(100.0),
+      battery_health:              Some(0.95),
       discharging:                 false,
       context:                     EvalContext::Cpu(&cpu),
       cpus:                        &cpus,
@@ -1294,11 +1335,15 @@ mod tests {
       cpu_frequency_maximum:       Some(3333.0),
       cpu_frequency_minimum:       Some(1000.0),
       cpu_scaling_maximum:         Some(3500.0),
+      cpu_core_count:              1,
       load_average_1m:             0.0,
       load_average_5m:             0.0,
       load_average_15m:            0.0,
+      lid_closed:                  false,
       power_supply_charge:         None,
       power_supply_discharge_rate: None,
+      battery_cycles:              None,
+      battery_health:              None,
       discharging:                 false,
       context:                     EvalContext::Cpu(&cpu),
       cpus:                        &cpus,

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -35,6 +35,33 @@ fn is_default<T: Default + PartialEq>(value: &T) -> bool {
   *value == T::default()
 }
 
+/// Find a power supply entry by name, excluding peripheral batteries.
+fn find_battery<'a>(
+  power_supplies: &'a HashSet<Arc<power_supply::PowerSupply>>,
+  name: &str,
+) -> Option<&'a power_supply::PowerSupply> {
+  power_supplies
+    .iter()
+    .find(|ps| {
+      ps.name == name && ps.type_ == "Battery" && !ps.is_from_peripheral
+    })
+    .map(|arc| arc.as_ref())
+}
+
+/// Find all non-peripheral battery power supplies.
+pub fn find_batteries(
+  power_supplies: &HashSet<Arc<power_supply::PowerSupply>>,
+) -> Vec<&power_supply::PowerSupply> {
+  // XXX: this repetition could be avoided if we extract the filter into
+  // something like is_battery() also at the module level but I don't think
+  // it's actually worth creating a function for.
+  power_supplies
+    .iter()
+    .filter(|ps| ps.type_ == "Battery" && !ps.is_from_peripheral)
+    .map(|arc| arc.as_ref())
+    .collect()
+}
+
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 #[serde(deny_unknown_fields, default, rename_all = "kebab-case")]
 pub struct CpusDelta {
@@ -724,16 +751,6 @@ impl Expression {
       ($expression:expr) => {
         try_ok!($expression.eval(state)?)
       };
-    }
-
-    fn find_battery<'a>(
-      power_supplies: &'a HashSet<Arc<power_supply::PowerSupply>>,
-      name: &str,
-    ) -> Option<&'a power_supply::PowerSupply> {
-      power_supplies
-        .iter()
-        .find(|ps| ps.name == name && ps.type_ == "Battery")
-        .map(|arc| arc.as_ref())
     }
 
     Ok(Some(match self {

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -35,16 +35,6 @@ fn is_default<T: Default + PartialEq>(value: &T) -> bool {
   *value == T::default()
 }
 
-fn find_battery<'a>(
-  power_supplies: &'a HashSet<Arc<power_supply::PowerSupply>>,
-  name: &str,
-) -> Option<&'a power_supply::PowerSupply> {
-  power_supplies
-    .iter()
-    .find(|ps| ps.name == name && ps.type_ == "Battery")
-    .map(|arc| arc.as_ref())
-}
-
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 #[serde(deny_unknown_fields, default, rename_all = "kebab-case")]
 pub struct CpusDelta {
@@ -736,6 +726,16 @@ impl Expression {
       };
     }
 
+    fn find_battery<'a>(
+      power_supplies: &'a HashSet<Arc<power_supply::PowerSupply>>,
+      name: &str,
+    ) -> Option<&'a power_supply::PowerSupply> {
+      power_supplies
+        .iter()
+        .find(|ps| ps.name == name && ps.type_ == "Battery")
+        .map(|arc| arc.as_ref())
+    }
+
     Ok(Some(match self {
       IsGovernorAvailable { value } => {
         let value = eval!(value);
@@ -810,7 +810,7 @@ impl Expression {
       IsBatteryAvailable { value } => {
         let value = eval!(value).try_into_string()?;
 
-        Boolean(find_battery(&state.power_supplies, &value).is_some())
+        Boolean(find_battery(state.power_supplies, &value).is_some())
       },
       FrequencyAvailable => Boolean(state.frequency_available),
       TurboAvailable => Boolean(state.turbo_available),
@@ -902,12 +902,12 @@ impl Expression {
       BatteryHealth => Number(try_ok!(state.battery_health)),
 
       BatteryCyclesFor { name } => {
-        let battery = find_battery(&state.power_supplies, name);
+        let battery = find_battery(state.power_supplies, name);
         Number(try_ok!(battery.and_then(|ps| ps.cycles).map(|c| c as f64)))
       },
 
       BatteryHealthFor { name } => {
-        let battery = find_battery(&state.power_supplies, name);
+        let battery = find_battery(state.power_supplies, name);
         Number(try_ok!(battery.and_then(|ps| ps.health)))
       },
 

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -451,7 +451,7 @@ pub enum Expression {
 
   CpuUsageSince {
     #[serde(rename = "cpu-usage-since")]
-    duration: String,
+    duration: Box<Expression>,
   },
 
   #[serde(with = "expression::cpu_temperature")]
@@ -477,7 +477,7 @@ pub enum Expression {
 
   LoadAverageSince {
     #[serde(rename = "load-average-since")]
-    duration: String,
+    duration: Box<Expression>,
   },
 
   #[serde(with = "expression::lid_closed")]
@@ -823,7 +823,8 @@ impl Expression {
         )
       },
       CpuUsageSince { duration } => {
-        let duration = humantime::parse_duration(duration)
+        let duration = eval!(duration).try_into_string()?;
+        let duration = humantime::parse_duration(&duration)
           .with_context(|| format!("failed to parse duration '{duration}'"))?;
         let recent_logs: Vec<&system::CpuLog> = state
           .cpu_log
@@ -865,7 +866,8 @@ impl Expression {
       CpuCoreCount => Number(state.cpus.len() as f64),
 
       LoadAverageSince { duration } => {
-        let duration = humantime::parse_duration(duration)
+        let duration = eval!(duration).try_into_string()?;
+        let duration = humantime::parse_duration(&duration)
           .with_context(|| format!("failed to parse duration '{duration}'"))?;
         let recent_logs: Vec<&system::CpuLog> = state
           .cpu_log

--- a/watt/config.toml
+++ b/watt/config.toml
@@ -4,8 +4,8 @@
 # Each rule can specify conditions and actions for CPU and power management.
 
 [[rule]]
-name     = "emergency-thermal-protection"
 if       = { is-more-than = 85.0, value = "$cpu-temperature" }
+name     = "emergency-thermal-protection"
 priority = 100
 
 cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "power", then = "power" }
@@ -15,8 +15,8 @@ cpu.governor                      = { if.is-governor-available = "powersave", th
 cpu.turbo                         = { if = "?turbo-available", then = false }
 
 [[rule]]
-name     = "critical-battery-preservation"
 if.all   = [ "?discharging", { is-less-than = 0.3, value = "%power-supply-charge" } ]
+name     = "critical-battery-preservation"
 priority = 90
 
 cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "power", then = "power" }
@@ -26,39 +26,51 @@ cpu.turbo                         = { if = "?turbo-available", then = false }
 power.platform-profile            = { if.is-platform-profile-available = "low-power", then = "low-power" }
 
 [[rule]]
-name = "high-load-performance-sustainance"
 if.all = [
-  { is-more-than = 0.8, value = "%cpu-usage" },
+  { is-more-than = 0.8, value = { cpu-usage-since = "2sec" } },
   { is-less-than = 30.0, value = "$cpu-idle-seconds" },
   { is-less-than = 75.0, value = "$cpu-temperature" },
 ]
+name = "high-load-performance-sustainance"
 priority = 80
 
-cpu.energy-perf-bias              = { if.all = [{ not.is-driver-loaded = "intel_pstate" }, { is-energy-perf-bias-available = "performance" }], then = "performance" }
-cpu.energy-performance-preference = { if.all = [{ not.is-driver-loaded = "intel_pstate" }, { is-energy-performance-preference-available = "performance" }], then = "performance" }
-cpu.governor                      = { if.is-governor-available = "performance", then = "performance" }
-cpu.turbo                         = { if = "?turbo-available", then = true }
+cpu.energy-perf-bias = { if.all = [
+  { not.is-driver-loaded = "intel_pstate" },
+  { is-energy-perf-bias-available = "performance" },
+], then = "performance" }
+cpu.energy-performance-preference = { if.all = [
+  { not.is-driver-loaded = "intel_pstate" },
+  { is-energy-performance-preference-available = "performance" },
+], then = "performance" }
+cpu.governor = { if.is-governor-available = "performance", then = "performance" }
+cpu.turbo = { if = "?turbo-available", then = true }
 
 [[rule]]
-name = "plugged-in-performance"
 if.all = [
   { not = "?discharging" },
-  { is-more-than = 0.1, value = "%cpu-usage" },
+  { is-more-than = 0.1, value = { cpu-usage-since = "1sec" } },
   { is-less-than = 80.0, value = "$cpu-temperature" },
 ]
+name = "plugged-in-performance"
 priority = 70
 
-cpu.energy-perf-bias              = { if.all = [{ not.is-driver-loaded = "intel_pstate" }, { is-energy-perf-bias-available = "balance-performance" }], then = "balance-performance" }
-cpu.energy-performance-preference = { if.all = [{ not.is-driver-loaded = "intel_pstate" }, { is-energy-performance-preference-available = "performance" }], then = "performance" }
-cpu.governor                      = { if.is-governor-available = "performance", then = "performance" }
-cpu.turbo                         = { if = "?turbo-available", then = true }
+cpu.energy-perf-bias = { if.all = [
+  { not.is-driver-loaded = "intel_pstate" },
+  { is-energy-perf-bias-available = "balance-performance" },
+], then = "balance-performance" }
+cpu.energy-performance-preference = { if.all = [
+  { not.is-driver-loaded = "intel_pstate" },
+  { is-energy-performance-preference-available = "performance" },
+], then = "performance" }
+cpu.governor = { if.is-governor-available = "performance", then = "performance" }
+cpu.turbo = { if = "?turbo-available", then = true }
 
 [[rule]]
-name = "moderate-load-balanced-performance"
 if.all = [
-  { is-more-than = 0.4, value = "%cpu-usage" },
-  { is-less-than = 0.8, value = "%cpu-usage" },
+  { is-more-than = 0.4, value = { cpu-usage-since = "5sec" } },
+  { is-less-than = 0.8, value = { cpu-usage-since = "5sec" } },
 ]
+name = "moderate-load-balanced-performance"
 priority = 60
 
 cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "balance-performance", then = "balance-performance" }
@@ -66,11 +78,11 @@ cpu.energy-performance-preference = { if.is-energy-performance-preference-availa
 cpu.governor                      = { if.is-governor-available = "schedutil", then = "schedutil" }
 
 [[rule]]
-name = "low-activity-power-saving"
 if.all = [
-  { is-less-than = 0.2, value = "%cpu-usage" },
+  { is-less-than = 0.2, value = { cpu-usage-since = "10sec" } },
   { is-more-than = 60.0, value = "$cpu-idle-seconds" },
 ]
+name = "low-activity-power-saving"
 priority = 50
 
 cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "power", then = "power" }
@@ -79,8 +91,8 @@ cpu.governor                      = { if.is-governor-available = "powersave", th
 cpu.turbo                         = { if = "?turbo-available", then = false }
 
 [[rule]]
-name     = "extended-idle-power-saving"
 if       = { is-more-than = 300.0, value = "$cpu-idle-seconds" }
+name     = "extended-idle-power-saving"
 priority = 40
 
 cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "power", then = "power" }
@@ -90,8 +102,8 @@ cpu.governor                      = { if.is-governor-available = "powersave", th
 cpu.turbo                         = { if = "?turbo-available", then = false }
 
 [[rule]]
-name     = "discharging-battery-conservation"
 if.all   = [ "?discharging", { is-less-than = 0.5, value = "%power-supply-charge" } ]
+name     = "discharging-battery-conservation"
 priority = 30
 
 cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "power", then = "power" }
@@ -102,8 +114,8 @@ cpu.turbo                         = { if = "?turbo-available", then = false }
 power.platform-profile            = { if.is-platform-profile-available = "low-power", then = "low-power" }
 
 [[rule]]
-name     = "battery-balanced"
 if       = "?discharging"
+name     = "battery-balanced"
 priority = 20
 
 cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "balance-performance", then = "balance-performance" }
@@ -114,8 +126,8 @@ cpu.governor                      = { if.is-governor-available = "powersave", th
 cpu.turbo                         = { if = "?turbo-available", then = false }
 
 [[rule]]
-name                              = "default-balanced"
 cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "balance-performance", then = "balance-performance" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "balance_performance", then = "balance_performance" }
 cpu.governor                      = { if.is-governor-available = "schedutil", then = "schedutil" }
+name                              = "default-balanced"
 priority                          = 0

--- a/watt/power_supply.rs
+++ b/watt/power_supply.rs
@@ -257,7 +257,7 @@ impl PowerSupply {
         .with_context(|| format!("failed to read {self} charge percent"))?
         .map(|percent| percent as f64 / 100.0);
 
-      self.cycles = fs::read_n::<u64>(self.path.join("cycles"))
+      self.cycles = fs::read_n::<u64>(self.path.join("cycle_count"))
         .with_context(|| format!("failed to read {self} cycle count"))?;
 
       // Battery health as a percentage (0-100)

--- a/watt/power_supply.rs
+++ b/watt/power_supply.rs
@@ -60,6 +60,9 @@ pub struct PowerSupply {
   pub charge_state:   Option<String>,
   pub charge_percent: Option<f64>,
 
+  pub cycle_count: Option<u64>,
+  pub health:      Option<f64>,
+
   pub charge_threshold_start: f64,
   pub charge_threshold_end:   f64,
 
@@ -154,6 +157,9 @@ impl PowerSupply {
 
         charge_state: None,
         charge_percent: None,
+
+        cycle_count: None,
+        health: None,
 
         charge_threshold_start: 0.0,
         charge_threshold_end: 1.0,
@@ -250,6 +256,35 @@ impl PowerSupply {
       self.charge_percent = fs::read_n::<u64>(self.path.join("capacity"))
         .with_context(|| format!("failed to read {self} charge percent"))?
         .map(|percent| percent as f64 / 100.0);
+
+      self.cycle_count = fs::read_n::<u64>(self.path.join("cycle_count"))
+        .with_context(|| format!("failed to read {self} cycle count"))?;
+
+      // Battery health as a percentage (0-100)
+      // Some systems report this as capacity_level or health
+      self.health = if let Some(health) =
+        fs::read_n::<u64>(self.path.join("health"))
+          .with_context(|| format!("failed to read {self} health"))?
+      {
+        Some(health as f64 / 100.0)
+      } else {
+        // Try to calculate health from energy_full vs energy_full_design
+        let energy_full = fs::read_n::<u64>(self.path.join("energy_full"))
+          .with_context(|| format!("failed to read {self} energy_full"))?;
+
+        let energy_full_design =
+          fs::read_n::<u64>(self.path.join("energy_full_design"))
+            .with_context(|| {
+              format!("failed to read {self} energy_full_design")
+            })?;
+
+        match (energy_full, energy_full_design) {
+          (Some(full), Some(design)) if design > 0 => {
+            Some(full as f64 / design as f64)
+          },
+          _ => None,
+        }
+      };
 
       self.charge_threshold_start =
         fs::read_n::<u64>(self.path.join("charge_control_start_threshold"))

--- a/watt/power_supply.rs
+++ b/watt/power_supply.rs
@@ -60,8 +60,8 @@ pub struct PowerSupply {
   pub charge_state:   Option<String>,
   pub charge_percent: Option<f64>,
 
-  pub cycle_count: Option<u64>,
-  pub health:      Option<f64>,
+  pub cycles: Option<u64>,
+  pub health: Option<f64>,
 
   pub charge_threshold_start: f64,
   pub charge_threshold_end:   f64,
@@ -158,7 +158,7 @@ impl PowerSupply {
         charge_state: None,
         charge_percent: None,
 
-        cycle_count: None,
+        cycles: None,
         health: None,
 
         charge_threshold_start: 0.0,
@@ -257,7 +257,7 @@ impl PowerSupply {
         .with_context(|| format!("failed to read {self} charge percent"))?
         .map(|percent| percent as f64 / 100.0);
 
-      self.cycle_count = fs::read_n::<u64>(self.path.join("cycle_count"))
+      self.cycles = fs::read_n::<u64>(self.path.join("cycles"))
         .with_context(|| format!("failed to read {self} cycle count"))?;
 
       // Battery health as a percentage (0-100)

--- a/watt/system.rs
+++ b/watt/system.rs
@@ -41,6 +41,9 @@ pub struct CpuLog {
 
   /// CPU temperature in celsius.
   pub temperature: f64,
+
+  /// Load average.
+  pub load_average: f64,
 }
 
 #[derive(Debug)]
@@ -200,6 +203,8 @@ impl System {
 
       temperature: self.cpu_temperatures.values().sum::<f64>()
         / self.cpu_temperatures.len() as f64,
+
+      load_average: self.load_average_1min,
     };
     log::debug!("appending CPU log item: {cpu_log:?}");
     self.cpu_log.push_back(cpu_log);
@@ -960,10 +965,6 @@ pub fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
       cpu_frequency_minimum:      cpu::Cpu::hardware_frequency_mhz_minimum()
         .context("failed to read CPU hardware minimum frequency")?
         .map(|u64| u64 as f64),
-
-      load_average_1m:  system.load_average_1min,
-      load_average_5m:  system.load_average_5min,
-      load_average_15m: system.load_average_15min,
 
       lid_closed: system.lid_closed,
 

--- a/watt/system.rs
+++ b/watt/system.rs
@@ -232,56 +232,51 @@ impl System {
     }
 
     // Aggregate battery cycle count and health
-    if !self.power_supplies.is_empty() {
-      let batteries: Vec<_> = self
-        .power_supplies
-        .iter()
-        .filter(|ps| ps.type_ == "Battery" && !ps.is_from_peripheral)
-        .collect();
+    let batteries: Vec<_> = self
+      .power_supplies
+      .iter()
+      .filter(|ps| ps.type_ == "Battery" && !ps.is_from_peripheral)
+      .collect();
 
-      if !batteries.is_empty() {
-        // Calculate average cycle count across all batteries
-        let (cycle_sum, cycles) =
-          batteries
-            .iter()
-            .fold((0u64, 0u32), |(sum, count), power_supply| {
-              if let Some(cycles) = power_supply.cycles {
-                (sum + cycles, count + 1)
-              } else {
-                (sum, count)
-              }
-            });
-
-        self.battery_cycles = if cycles > 0 {
-          Some(cycle_sum as f64 / cycles as f64)
-        } else {
-          None
-        };
-
-        // Calculate average health across all batteries
-        let (health_sum, health_count) =
-          batteries
-            .iter()
-            .fold((0.0, 0u32), |(sum, count), power_supply| {
-              if let Some(health) = power_supply.health {
-                (sum + health, count + 1)
-              } else {
-                (sum, count)
-              }
-            });
-
-        self.battery_health = if health_count > 0 {
-          Some(health_sum / health_count as f64)
-        } else {
-          None
-        };
-      } else {
-        self.battery_cycles = None;
-        self.battery_health = None;
-      }
-    } else {
+    if self.power_supplies.is_empty() || batteries.is_empty() {
       self.battery_cycles = None;
       self.battery_health = None;
+    } else {
+      // Calculate average cycle count across all batteries
+      let (cycle_sum, cycles) =
+        batteries
+          .iter()
+          .fold((0u64, 0u32), |(sum, count), power_supply| {
+            if let Some(cycles) = power_supply.cycles {
+              (sum + cycles, count + 1)
+            } else {
+              (sum, count)
+            }
+          });
+
+      self.battery_cycles = if cycles > 0 {
+        Some(cycle_sum as f64 / cycles as f64)
+      } else {
+        None
+      };
+
+      // Calculate average health across all batteries
+      let (health_sum, health_count) =
+        batteries
+          .iter()
+          .fold((0.0, 0u32), |(sum, count), power_supply| {
+            if let Some(health) = power_supply.health {
+              (sum + health, count + 1)
+            } else {
+              (sum, count)
+            }
+          });
+
+      self.battery_health = if health_count > 0 {
+        Some(health_sum / health_count as f64)
+      } else {
+        None
+      };
     }
 
     Ok(())

--- a/watt/system.rs
+++ b/watt/system.rs
@@ -241,19 +241,19 @@ impl System {
 
       if !batteries.is_empty() {
         // Calculate average cycle count across all batteries
-        let (cycle_sum, cycle_count) =
+        let (cycle_sum, cycles) =
           batteries
             .iter()
             .fold((0u64, 0u32), |(sum, count), power_supply| {
-              if let Some(cycles) = power_supply.cycle_count {
+              if let Some(cycles) = power_supply.cycles {
                 (sum + cycles, count + 1)
               } else {
                 (sum, count)
               }
             });
 
-        self.battery_cycles = if cycle_count > 0 {
-          Some(cycle_sum as f64 / cycle_count as f64)
+        self.battery_cycles = if cycles > 0 {
+          Some(cycle_sum as f64 / cycles as f64)
         } else {
           None
         };

--- a/watt/system.rs
+++ b/watt/system.rs
@@ -961,16 +961,6 @@ pub fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
         .context("failed to read CPU hardware minimum frequency")?
         .map(|u64| u64 as f64),
 
-      cpu_scaling_maximum: system
-        .cpus
-        .iter()
-        .map(|cpu| cpu.frequency_mhz_maximum)
-        .max()
-        .flatten()
-        .map(|u64| u64 as f64),
-
-      cpu_core_count: system.cpus.len() as u32,
-
       load_average_1m:  system.load_average_1min,
       load_average_5m:  system.load_average_5min,
       load_average_15m: system.load_average_15min,

--- a/watt/system.rs
+++ b/watt/system.rs
@@ -798,6 +798,18 @@ pub fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
         .context("failed to read CPU hardware minimum frequency")?
         .map(|u64| u64 as f64),
 
+      cpu_scaling_maximum: system
+        .cpus
+        .iter()
+        .map(|cpu| cpu.frequency_mhz_maximum)
+        .max()
+        .flatten()
+        .map(|u64| u64 as f64),
+
+      load_average_1m:  system.load_average_1min,
+      load_average_5m:  system.load_average_5min,
+      load_average_15m: system.load_average_15min,
+
       power_supply_charge:         system
         .power_supply_log
         .back()

--- a/watt/system.rs
+++ b/watt/system.rs
@@ -237,11 +237,7 @@ impl System {
     }
 
     // Aggregate battery cycle count and health
-    let batteries: Vec<_> = self
-      .power_supplies
-      .iter()
-      .filter(|ps| ps.type_ == "Battery" && !ps.is_from_peripheral)
-      .collect();
+    let batteries = config::find_batteries(&self.power_supplies);
 
     if self.power_supplies.is_empty() || batteries.is_empty() {
       self.battery_cycles = None;

--- a/watt/system.rs
+++ b/watt/system.rs
@@ -559,12 +559,9 @@ impl System {
       fs::read_dir(INPUT_PATH).context("failed to read input device entries")?
     {
       for entry in input_entries {
-        let entry = match entry {
-          Ok(entry) => entry,
-          Err(error) => {
-            log::debug!("failed to read input device entry: {error}");
-            continue;
-          },
+        let Ok(entry) = entry else {
+          log::debug!("failed to read input device entry");
+          continue;
         };
 
         let entry_path = entry.path();
@@ -581,36 +578,38 @@ impl System {
         };
 
         // Look for lid switch input device
-        if name.trim() == "Lid Switch" {
-          // Read the lid switch state from the SW_LID capability
-          let state_path = entry_path.join("device/capabilities/sw");
+        let "Lid Switch" = name.trim() else {
+          continue;
+        };
 
-          let Some(sw_caps) = fs::read(&state_path).with_context(|| {
-            format!(
-              "failed to read switch capabilities from '{path}'",
-              path = state_path.display(),
-            )
-          })?
-          else {
-            log::debug!(
-              "found lid switch at {path} but no switch capabilities file",
-              path = entry_path.display()
-            );
-            continue;
-          };
+        // Read the lid switch state from the SW_LID capability
+        let state_path = entry_path.join("device/capabilities/sw");
 
-          // SW_LID is bit 0 in the capabilities bitmask
-          // The state file shows the current state of switches as a hex bitmask
-          // If bit 0 is set, the lid is closed
-          if let Ok(caps) = u64::from_str_radix(sw_caps.trim(), 16) {
-            self.lid_closed = (caps & 0x1) != 0;
-            log::debug!(
-              "lid state from input device {path}: {state}",
-              path = entry_path.display(),
-              state = if self.lid_closed { "closed" } else { "open" }
-            );
-            return Ok(());
-          }
+        let Some(sw_caps) = fs::read(&state_path).with_context(|| {
+          format!(
+            "failed to read switch capabilities from '{path}'",
+            path = state_path.display(),
+          )
+        })?
+        else {
+          log::debug!(
+            "found lid switch at {path} but no switch capabilities file",
+            path = entry_path.display()
+          );
+          continue;
+        };
+
+        // SW_LID is bit 0 in the capabilities bitmask
+        // The state file shows the current state of switches as a hex bitmask
+        // If bit 0 is set, the lid is closed
+        if let Ok(caps) = u64::from_str_radix(sw_caps.trim(), 16) {
+          self.lid_closed = (caps & 0x1) != 0;
+          log::debug!(
+            "lid state from input device {path}: {state}",
+            path = entry_path.display(),
+            state = if self.lid_closed { "closed" } else { "open" }
+          );
+          return Ok(());
         }
       }
     }


### PR DESCRIPTION
Adds a few new system variables per #45. New variables:

- `$cpu-scaling-maximum - CPU scaling maximum frequency in MHz
- `%cpu-core-count` - Number of CPU cores
- `$load-average-since` System load average over a given duration
- `?lid-closed` - Boolean for lid state
- `$hour-of-day` - Current hour (0-23) based on local time
- `$battery-cycles` - Battery cycle count
- `%battery-health` - Battery health percentage

Notes:

- `%cpu-usage` is now fully deprecated. Updated example config with best-case examples I can think of. Could be optimized further if we decide to actually benchmark power consumption on a live system.

- Like we do for CPU usage, it's worth adding support for measuring load average over certain durations rather than just fixed 1m, 5m and 15m averages.
  - A system with many I/O-bound processes can show high load average but low CPU usage. Conversely, a few CPU-intensive tasks can show high CPU usage but moderate load. In this case we have a good reason to distinguish the two.

- `$cpu-scaling-minimum` is not added, because minimum should be always 0. Maximum is what we'll want to use to infer system "capability". I cannot think of a single case where it will *not* be 0.

- `?$hour-of-day` is added despite my belief that it'll be obsoleted by the D-Bus interface. It's a trivial addition, and I'd rather not curse people with D-Bus for something so trivial. It's good for some basic rules, and of trivial cost.

- I'm not particularly proud of the battery aggregation. This'll need to be polished to support per-battery supports.
