### PR TITLE
watt: add new power and performance policy rules; minor configuration updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,33 @@
-<!-- markdownlint-disable MD013 MD033-->
-
-<h1 id="header" align="center">
-    <pre>Watt</pre>
-</h1>
+<!--markdownlint-disable MD013 MD033 MD041-->
 
 <div align="center">
+  <h1 id="header">
+    <pre>Watt</pre>
+  </h1>
+  <div>
     <a alt="CI" href="https://github.com/NotAShelf/watt/actions">
-        <img
-          src="https://github.com/NotAShelf/watt/actions/workflows/build.yml/badge.svg"
-          alt="Build Status"
-        />
+      <img
+        src="https://github.com/NotAShelf/watt/actions/workflows/build.yml/badge.svg"
+        alt="Build Status"
+      />
     </a>
     <a alt="License" href="https://github.com/notashelf/watt/blob/master/LICENSE">
-        <img
-          src="https://img.shields.io/github/license/notashelf/watt?label=License"
-          alt="License"
-        />
+      <img
+        src="https://img.shields.io/github/license/notashelf/watt?label=License"
+        alt="License"
+      />
     </a>
-</div>
-
-<div align="center">
-  Modern, transparent and intelligent utility for CPU management on Linux.
-</div>
-
-<div align="center">
-  <br/>
-  <a href="#watt-is-it">Synopsis</a><br/>
-  <a href="#features">Features</a> | <a href="#usage">Usage</a><br/>
-  <a href="#contributing">Contributing</a>
-  <br/>
+  </div>
+  <div>
+    Modern, transparent and intelligent utility for CPU management on Linux.
+  </div>
+  <div>
+    <br/>
+    <a href="#watt-is-it">Synopsis</a><br/>
+    <a href="#features">Features</a> | <a href="#usage">Usage</a> | <a href="#configuration">Configuration</a><br/>
+    <a href="#contributing">Contributing</a>
+    <br/>
+  </div>
 </div>
 
 ## Watt Is It?
@@ -60,21 +59,18 @@ daemons.
 Watt is a tiny binary with a small footprint, but it packs a bunch. Namely:
 
 - **Daemon Mode**: Run in background with adaptive polling to minimize overhead.
-- **Real-time CPU Management**: Monitor and control CPU governors, frequencies,
-  and turbo boost.
+- **Rule-Based Power Policy**: Evaluate declarative TOML rules against live
+  system state, then apply the highest-priority matching settings.
+- **CPU Management**: Monitor and control CPU governors, frequencies, turbo
+  boost, EPP/EPB, Intel P-State limits and PM QoS latency controls.
+- **Device Power Controls**: Tune power-related settings for batteries, ACPI
+  platform profiles, disks, USB devices, audio codecs, GPUs, Intel uncore
+  frequency and VM memory policy.
 - **Conflict Detection**: Identifies and warns about conflicts with other power
   management tools.
 - **Powerful Config DSL**: Built on TOML, Watt features a robust configuration
-  DSL to allow configuring the daemon _exactly_ to your needs.
-  - **Intelligent Power Management**: Different profiles for AC and battery
-    operation.
-  - **Dynamic Turbo Boost Control**: Automatically enables/disables turbo based
-    on CPU load and temperature.
-  - **Fine-tuned Controls**: Adjust energy performance preferences, biases, and
-    frequency limits.
-  - **Per-core Control**: Apply settings globally or to specific CPU cores.
-  - **Battery Management**: Monitor battery status and power consumption.
-  - **System Load Tracking**: Track system load and make intelligent decisions.
+  DSL for conditions, arithmetic, availability checks, target selection and
+  fallback values.
 
 ## Usage
 
@@ -104,134 +100,13 @@ sudo watt -vv  # Log level: TRACE (will log everything)
 sudo watt --config /path/to/config.toml
 ```
 
-### CPU Management
-
-Watt operates primarily as a daemon that runs in the background and
-automatically manages CPU and power settings based on set configuration rules,
-using the various kernel power management APIs. All CPU settings are specified
-in the configuration file:
-
-```toml
-[[rule]]
-if = "?discharging"
-priority = 10
-
-cpu.governor = "powersave"
-cpu.energy-performance-preference = "power"
-cpu.turbo = false
-```
-
-You can apply settings to specific CPU cores by listing their IDs with
-`cpu.for`:
-
-```toml
-[[rule]]
-cpu.for = [0, 1]  # Apply to first two cores
-cpu.governor = "performance"
-```
-
-### Power Management
-
-Power settings are also specified in the configuration file. Use `power.for` to
-target specific power supply names:
-
-```toml
-[[rule]]
-if = "?discharging"
-priority = 10
-
-# Set battery charging thresholds (as percentages, 0-100)
-power.charge-threshold-start = 40
-power.charge-threshold-end = 80
-
-# Set ACPI platform profile
-power.platform-profile = "low-power"
-
-# Apply to specific power supplies
-power.for = ["BAT0"]
-```
-
-Battery charging thresholds help extend battery longevity by preventing constant
-charging to 100%. Watt supports multiple threshold implementations including:
-
-- Lenovo ThinkPad/IdeaPad
-- ASUS laptops
-- Huawei laptops
-- Framework laptops
-- Other devices using the standard Linux power_supply API
-
-> [!NOTE]
-> Battery management is sensitive, and your mileage may vary. Please open an
-> issue if your vendor is not supported, but patches would help more than issue
-> reports, as supporting hardware _needs_ hardware.
-
-### Advanced Configuration Examples
-
-#### Complex Condition Logic
-
-```toml
-# High performance for sustained workloads with thermal protection
-[[rule]]
-if.all = [
-  { is-more-than = 0.8, value = { cpu-usage-since = "2sec" } },
-  { is-less-than = 30.0, value = "$cpu-idle-seconds" },
-  { is-less-than = 75.0, value = "$cpu-temperature" },
-]
-priority = 80
-
-cpu.governor = "performance"
-cpu.energy-performance-preference = "performance"
-cpu.turbo = true
-```
-
-#### Battery Conservation with Multiple Thresholds
-
-```toml
-# Critical battery preservation
-[[rule]]
-if.all = [
-  "?discharging",
-  { is-less-than = 0.3, value = "%power-supply-charge" }
-]
-priority = 90
-
-cpu.governor = "powersave"
-cpu.energy-performance-preference = "power"
-cpu.frequency-mhz-maximum = 800
-cpu.turbo = false
-power.platform-profile = "low-power"
-
-# Moderate battery conservation
-[[rule]]
-if.all = [
-  "?discharging",
-  { is-less-than = 0.5, value = "%power-supply-charge" }
-]
-priority = 30
-
-cpu.governor = "powersave"
-cpu.frequency-mhz-maximum = 2000
-cpu.turbo = false
-```
-
-#### Using Arithmetic Expressions
-
-```toml
-# Adaptive frequency scaling based on temperature
-[[rule]]
-if = { is-more-than = 10.0, value = { value = "$cpu-temperature", minus = 50.0 } }
-priority = 60
-
-cpu.frequency-mhz-maximum = 2400
-cpu.governor = "schedutil"
-```
-
 ## Configuration
 
-Watt uses a rule-based TOML configuration system that allows you to define
-intelligent power management policies. The daemon evaluates rules by priority
-and applies the all matching rules. Rule settings with higher priority shadow
-ones with lower priority.
+Watt uses a rule-based TOML configuration system that allows you to define power
+management policies. Each `[[rule]]` has an optional condition, a unique
+priority and one or more action sections. Watt evaluates matching rules from
+highest to lowest priority; higher-priority values fill each setting first, and
+lower-priority rules only fill settings that remain unset.
 
 ### Configuration Locations
 
@@ -250,308 +125,34 @@ configuration. You can find the default configuration in the [watt crate].
 
 <!--markdownlint-enable MD059 -->
 
-### Rule-Based Configuration
+Rules can target CPU cores, power supplies, Intel uncore devices, disks, USB
+devices and GPUs with `*.for` selectors where the subsystem has named devices.
+Global sections such as `vm`, `audio`, `disk.alpm` and `power.platform-profile`
+apply once per polling cycle.
 
-Rules are the core of Watt's configuration system. Each rule can specify:
+For the full rule syntax, expression reference and every supported action, see
+[Configuring Watt](docs/configuring.md).
 
-- **Conditions**: When the rule should apply (using the expression DSL). If not
-  specified, always applies (defaults to `true`).
-- **Priority**: Higher numbers take precedence (0-65535).
-- **Actions**: CPU and power management settings to apply.
-
-### Expression DSL
-
-Watt includes a powerful expression language for defining conditions:
-
-#### Constants
-
-- `true`, `false` - Booleans
-- `123.456`, `42` - 64-bit Floats
-
-#### System Variables
-
-- `{ cpu-usage-since = "<duration>" }` - CPU usage percentage over a duration
-  (e.g., `"1sec"`, `"5sec"`)
-- `"$cpu-usage-volatility"` - CPU usage volatility measurement
-- `"$cpu-temperature"` - CPU temperature in Celsius
-- `"$cpu-temperature-volatility"` - CPU temperature volatility
-- `"$cpu-idle-seconds"` - Seconds since last significant CPU activity
-- `"$cpu-frequency-maximum"` - CPU hardware maximum frequency in MHz
-- `"$cpu-frequency-minimum"` - CPU hardware minimum frequency in MHz
-- `"$cpu-scaling-maximum"` - Current CPU scaling maximum frequency in MHz (from
-  `scaling_max_freq`)
-- `"%cpu-core-count"` - Number of CPU cores
-- `{ load-average-since = "<duration>" }` - System load average over a duration
-  (e.g., `"5sec"`, `"1min"`)
-- `"$hour-of-day"` - Current hour (0-23) based on system local time
-- `"?lid-closed"` - Boolean indicating if laptop lid is closed
-- `"%power-supply-charge"` - Battery charge percentage (0.0-1.0)
-- `"%power-supply-discharge-rate"` - Current discharge rate
-- `"%battery-cycles"` - Battery cycle count (aggregated average across all
-  batteries)
-- `"%battery-health"` - Battery health percentage (0.0-1.0, aggregated average
-  across all batteries)
-- `{ battery-cycles-for = "<name>" }` - Battery cycle count for a specific
-  battery (e.g., `"BAT0"`)
-- `{ battery-health-for = "<name>" }` - Battery health for a specific battery
-- `"?discharging"` - Boolean indicating if system is on battery power
-- `"?frequency-available"` - Boolean indicating if CPU frequency control is
-  available
-- `"?turbo-available"` - Boolean indicating if turbo boost control is available
-
-The expression language only has boolean and 64-bit float values.
-
-#### Predicates
-
-Predicates check if a specific value is available on the system:
+### Example
 
 ```toml
-if.is-governor-available = "powersave"
-if.is-energy-performance-preference-available = "balance_performance"
-if.is-energy-perf-bias-available = "5"
-if.is-platform-profile-available = "low-power"
-if.is-driver-loaded = "intel_pstate"
-if.is-battery-available = "BAT0"
-```
-
-Each will be `true` only if the named value is available on your system. If the
-argument is not a string, Watt will fail with a configuration error.
-
-#### Operators
-
-- **Comparison**: `is-less-than`, `is-more-than`, `is-equal` (with `leeway`
-  parameter)
-- **Logical**: `and`, `or`, `not`, `all`, `any`
-- **Arithmetic**: `plus`, `minus`, `multiply`, `divide`, `power`
-- **Aggregation**: `minimum`, `maximum` - take a list of expressions
-
-You can use operators with TOML attribute sets:
-
-```toml
-[[rule]]
-if = { is-more-than = { cpu-usage-since = "1sec" }, value = 0.8 }
-```
-
-However, `all` and `any` do not take a `value` argument, but instead take a list
-of expressions as the parameter:
-
-```toml
-[[rule]]
-if = { all = [ <expression>, <expression2> ] }
-```
-
-#### Conditional Values
-
-Settings can be conditionally applied based on availability:
-
-```toml
-cpu.governor = { if.is-governor-available = "powersave", then = "powersave" }
-cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "balance_performance", then = "balance_performance" }
-cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "5", then = "5" }
-cpu.frequency-mhz-maximum = { if = "?frequency-available", then = 2000 }
-cpu.turbo = { if = "?turbo-available", then = true }
-```
-
-If the condition is not met, the setting will not be applied.
-
-### Basic Configuration Example
-
-```toml
-# Emergency thermal protection (highest priority)
-[[rule]]
-if = { is-more-than = 85.0, value = "$cpu-temperature" }
-priority = 100
-
-cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "power", then = "power" }
-cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
-cpu.frequency-mhz-maximum = { if = "?frequency-available", then = 2000 }
-cpu.governor = { if.is-governor-available = "powersave", then = "powersave" }
-cpu.turbo = { if = "?turbo-available", then = false }
-
-# Critical battery preservation
 [[rule]]
 if.all = [ "?discharging", { is-less-than = 0.3, value = "%power-supply-charge" } ]
+name     = "battery-preservation"
 priority = 90
 
-cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "power", then = "power" }
-cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
-cpu.frequency-mhz-maximum = 800
-cpu.governor = { if.is-governor-available = "powersave", then = "powersave" }
-cpu.turbo = { if = "?turbo-available", then = false }
-power.platform-profile = { if.is-platform-profile-available = "low-power", then = "low-power" }
-
-# High performance mode for sustained high load
-[[rule]]
-if.all = [
-  { is-more-than = 0.8, value = { cpu-usage-since = "2sec" } },
-  { is-less-than = 30.0, value = "$cpu-idle-seconds" },
-  { is-less-than = 75.0, value = "$cpu-temperature" },
-]
-priority = 80
-
-cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "performance", then = "performance" }
-cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "performance", then = "performance" }
-cpu.governor = { if.is-governor-available = "performance", then = "performance" }
-cpu.turbo = { if = "?turbo-available", then = true }
-
-# Performance mode when not discharging
-[[rule]]
-if.all = [
-  { not = "?discharging" },
-  { is-more-than = 0.1, value = { cpu-usage-since = "1sec" } },
-  { is-less-than = 80.0, value = "$cpu-temperature" },
-]
-priority = 70
-
-cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "balance-performance", then = "balance-performance" }
-cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "performance", then = "performance" }
-cpu.governor = { if.is-governor-available = "performance", then = "performance" }
-cpu.turbo = { if = "?turbo-available", then = true }
-
-# Moderate performance for medium load
-[[rule]]
-if.all = [
-  { is-more-than = 0.4, value = { cpu-usage-since = "5sec" } },
-  { is-less-than = 0.8, value = { cpu-usage-since = "5sec" } },
-]
-priority = 60
-
-cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "balance-performance", then = "balance-performance" }
-cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "balance_performance", then = "balance_performance" }
-cpu.governor = { if.is-governor-available = "schedutil", then = "schedutil" }
-
-# Power saving during low activity
-[[rule]]
-if.all = [
-  { is-less-than = 0.2, value = { cpu-usage-since = "10sec" } },
-  { is-more-than = 60.0, value = "$cpu-idle-seconds" },
-]
-priority = 50
-
-cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "power", then = "power" }
-cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
-cpu.governor = { if.is-governor-available = "powersave", then = "powersave" }
+cpu.governor = { first-available-governor = ["powersave", "schedutil"] }
+cpu.energy-performance-preference = { first-available-energy-performance-preference = ["power", "balance_power"] }
 cpu.turbo = { if = "?turbo-available", then = false }
 
-# Extended idle power optimization
-[[rule]]
-if = { is-more-than = 300.0, value = "$cpu-idle-seconds" }
-priority = 40
+power.platform-profile = { first-available-platform-profile = ["low-power", "quiet"] }
+power.charge-threshold-start = 40
+power.charge-threshold-end = 80
 
-cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "power", then = "power" }
-cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
-cpu.frequency-mhz-maximum = { if = "?frequency-available", then = 1600 }
-cpu.governor = { if.is-governor-available = "powersave", then = "powersave" }
-cpu.turbo = { if = "?turbo-available", then = false }
-
-# Battery conservation when discharging
-[[rule]]
-if.all = [ "?discharging", { is-less-than = 0.5, value = "%power-supply-charge" } ]
-priority = 30
-
-cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "power", then = "power" }
-cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
-cpu.frequency-mhz-maximum = { if = "?frequency-available", then = 2000 }
-cpu.governor = { if.is-governor-available = "powersave", then = "powersave" }
-cpu.turbo = { if = "?turbo-available", then = false }
-power.platform-profile = { if.is-platform-profile-available = "low-power", then = "low-power" }
-
-# General battery mode
-[[rule]]
-if = "?discharging"
-priority = 20
-
-cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "balance-power", then = "balance-power" }
-cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
-cpu.frequency-mhz-maximum = { if = "?frequency-available", then = 1800 }
-cpu.frequency-mhz-minimum = { if = "?frequency-available", then = 200 }
-cpu.governor = { if.is-governor-available = "powersave", then = "powersave" }
-cpu.turbo = { if = "?turbo-available", then = false }
-
-# Balanced performance for general use - Default fallback rule
-[[rule]]
-priority = 0
-
-cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "balance-performance", then = "balance-performance" }
-cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "balance_performance", then = "balance_performance" }
-cpu.governor = { if.is-governor-available = "schedutil", then = "schedutil" }
+usb.autosuspend = true
+audio.timeout-seconds = 10
+gpu.panel-power-savings = { if.is-chassis-type = "laptop", then = 3 }
 ```
-
-### CPU Settings
-
-Available CPU configuration options:
-
-- `governor` - CPU frequency governor (`performance`, `powersave`, `schedutil`,
-  etc.). You can conditionally set a governor only if it is available using:
-
-  ```toml
-  cpu.governor = { if.is-governor-available = "powersave", then = "powersave" }
-  ```
-
-  If the governor name is not a string, Watt will fail with a configuration
-  error.
-
-- `energy-performance-preference` - EPP setting (`performance`,
-  `balance_performance`, `balance_power`, `power`, etc.). You can conditionally
-  set an EPP only if it is available using:
-
-  ```toml
-  cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "balance_performance", then = "balance_performance" }
-  ```
-
-- `energy-perf-bias` - EPB setting (`performance`, `balance-performance`,
-  `balance-power`, `power`, etc.). You can conditionally set an EPB only if it
-  is available using:
-
-  ```toml
-  cpu.energy-perf-bias = { if.is-energy-perf-bias-available = "5", then = "5" }
-  ```
-
-- `frequency-mhz-minimum` - Minimum CPU frequency in MHz. Can use conditional
-  expression:
-
-  ```toml
-  cpu.frequency-mhz-minimum = { if = "?frequency-available", then = 200 }
-  ```
-
-- `frequency-mhz-maximum` - Maximum CPU frequency in MHz. Can use conditional
-  expression:
-
-  ```toml
-  cpu.frequency-mhz-maximum = { if = "?frequency-available", then = 3000 }
-  ```
-
-- `turbo` - Enable/disable turbo boost (boolean). Can use conditional
-  expression:
-
-  ```toml
-  cpu.turbo = { if = "?turbo-available", then = true }
-  ```
-
-- `for` - Apply settings to specific CPU cores (list of core IDs):
-
-  ```toml
-  cpu.for = [0, 1, 2]
-  ```
-
-### Power Settings
-
-Available power management options:
-
-- `platform-profile` - ACPI platform profile (`performance`, `balanced`,
-  `low-power`). Can use conditional expression:
-
-  ```toml
-  power.platform-profile = { if.is-platform-profile-available = "low-power", then = "low-power" }
-  ```
-
-- `charge-threshold-start` - Battery charge level to start charging (0-100)
-- `charge-threshold-end` - Battery charge level to stop charging (0-100)
-- `for` - Apply settings to specific power supplies (list of supply names):
-
-  ```toml
-  power.for = ["BAT0"]
-  ```
 
 ## Troubleshooting
 
@@ -567,6 +168,8 @@ Not all features are available on all hardware:
 - Turbo boost control requires CPU support for Intel/AMD boost features
 - EPP/EPB settings require CPU driver support
 - Platform profiles require ACPI platform profile support in your hardware
+- Disk APM and spindown settings require `hdparm` and compatible drives
+- GPU panel power savings require compatible AMDGPU panel sysfs support
 
 ### Common Problems
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1,0 +1,362 @@
+# Configuring Watt
+
+Watt is configured with TOML rules. Each `[[rule]]` may have a `name`, a unique
+`priority`, an optional `if` condition and one or more action sections. Rules
+are evaluated from highest to lowest priority. When several matching rules set
+the same option, the highest-priority value wins and lower-priority rules only
+fill settings that were not set yet.
+
+## Configuration Sources
+
+Configuration is loaded in this order:
+
+- `--config /path/to/config.toml`
+- `WATT_CONFIG=/path/to/config.toml`
+- the built-in default at `watt/config.toml`
+
+Metrics are configured with a top-level `[metrics]` table when Watt is built
+with `--features metrics`:
+
+```toml
+[metrics]
+listen-addr = "[::]"
+port = 9790
+```
+
+## Rule Structure
+
+<!--markdownlint-disable MD013-->
+
+```toml
+[[rule]]
+name = "battery-low-power"
+priority = 50
+if.all = ["?discharging", { is-less-than = 0.5, value = "%power-supply-charge" }]
+
+cpu.governor = { first-available-governor = ["powersave", "schedutil"] }
+cpu.turbo = { if = "?turbo-available", then = false }
+power.platform-profile = { first-available-platform-profile = ["low-power", "quiet"] }
+usb.autosuspend = true
+```
+
+<!--markdownlint-enable MD013-->
+
+If `if` is omitted, the rule always applies. `priority` is a `u16`, so valid
+values are `0` through `65535`.
+
+## Expressions
+
+Expressions are used in rule conditions and action values. A setting may resolve
+to no value; in that case Watt leaves that setting unset and lower-priority
+rules may still fill it.
+
+Constants:
+
+- `true` and `false`
+- numbers such as `42` and `0.75`
+- strings such as `"powersave"`
+- lists such as `["schedutil", "powersave"]`
+
+System state expressions:
+
+- `{ cpu-usage-since = "<duration>" }`
+- `"$cpu-usage-volatility"`
+- `"$cpu-temperature"`
+- `"$cpu-temperature-volatility"`
+- `"$cpu-idle-seconds"`
+- `"$cpu-frequency-maximum"`
+- `"$cpu-frequency-minimum"`
+- `"$cpu-scaling-maximum"`
+- `"%cpu-core-count"`
+- `{ load-average-since = "<duration>" }`
+- `"$hour-of-day"`
+- `"?lid-closed"`
+- `"?virtual-machine"`
+- `"%power-supply-charge"`
+- `"%power-supply-discharge-rate"`
+- `"$battery-cycles"`
+- `"%battery-health"`
+- `{ battery-cycles-for = "BAT0" }`
+- `{ battery-health-for = "BAT0" }`
+- `"?discharging"`
+- `"?frequency-available"`
+- `"?turbo-available"`
+- `"$power-profile-preference"`
+
+Predicates:
+
+- `{ is-governor-available = "powersave" }`
+- `{ is-energy-performance-preference-available = "power" }`
+- `{ is-energy-perf-bias-available = "balance-power" }`
+- `{ is-platform-profile-available = "low-power" }`
+- `{ is-driver-loaded = "intel_pstate" }`
+- `{ is-battery-available = "BAT0" }`
+- `{ is-chassis-type = "laptop" }`
+
+Fallback selectors:
+
+- `{ first-available-governor = ["schedutil", "powersave"] }`
+- `{ first-available-energy-performance-preference = ["balance_power", "power"] }`
+- `{ first-available-energy-perf-bias = ["balance-power", "power"] }`
+- `{ first-available-platform-profile = ["low-power", "quiet"] }`
+
+Operators:
+
+- `{ is-less-than = 80.0, value = "$cpu-temperature" }`
+- `{ is-more-than = 0.8, value = { cpu-usage-since = "2sec" } }`
+- `{ is-equal = 12.0, value = "$hour-of-day", leeway = 0.5 }`
+- `{ value = "$cpu-temperature", minus = 50.0 }`
+- `{ value = "$cpu-frequency-maximum", multiply = 0.65 }`
+- `{ value = 10.0, plus = 5.0 }`
+- `{ value = 10.0, divide = 2.0 }`
+- `{ value = 2.0, power = 3.0 }`
+- `{ all = ["?discharging", { is-less-than = 0.5, value = "%power-supply-charge" }] }`
+- `{ any = ["?virtual-machine", { is-chassis-type = "desktop" }] }`
+- `{ not = "?discharging" }`
+- `{ minimum = ["$cpu-temperature", 80.0] }`
+- `{ maximum = ["$cpu-frequency-minimum", 1000.0] }`
+
+Conditional values use `if`, `then` and optional `else`:
+
+```toml
+cpu.turbo = { if = "?turbo-available", then = false }
+cpu.governor = { if.is-governor-available = "schedutil", then = "schedutil", else = "powersave" }
+```
+
+## CPU Actions
+
+CPU actions go under `cpu`. Use `cpu.for` to target CPU numbers; otherwise the
+setting applies to every detected CPU where that setting is per-CPU.
+
+```toml
+[[rule]]
+priority = 10
+cpu.for = [0, 1]
+cpu.governor = "performance"
+```
+
+Supported CPU fields:
+
+- `cpu.for`: list of CPU IDs
+- `cpu.governor`: CPU frequency governor string
+- `cpu.energy-performance-preference`: EPP string
+- `cpu.energy-perf-bias`: EPB string
+- `cpu.frequency-mhz-minimum`: minimum scaling frequency in MHz
+- `cpu.frequency-mhz-maximum`: maximum scaling frequency in MHz
+- `cpu.turbo`: global turbo/boost boolean
+- `cpu.pstate-min-performance-percent`: Intel P-State minimum percentage
+- `cpu.pstate-max-performance-percent`: Intel P-State maximum percentage
+- `cpu.dma-latency-us`: global `/dev/cpu_dma_latency` request in microseconds up
+  to `2147483647`
+- `cpu.pm-qos-resume-latency-us`: per-CPU PM QoS resume latency in microseconds
+  or `"n/a"`
+
+Example:
+
+```toml
+[[rule]]
+if.all = ["?discharging", { is-less-than = 0.5, value = "%power-supply-charge" }]
+priority = 80
+
+cpu.governor = { first-available-governor = ["powersave", "schedutil"] }
+cpu.energy-performance-preference = { first-available-energy-performance-preference = ["power", "balance_power"] }
+cpu.frequency-mhz-maximum = { if = "?frequency-available", then = 1800 }
+cpu.turbo = { if = "?turbo-available", then = false }
+cpu.pstate-max-performance-percent = 60
+cpu.pm-qos-resume-latency-us = "n/a"
+```
+
+## Power Supply Actions
+
+Power supply actions go under `power`. Use `power.for` to target power supply
+names such as `BAT0`; otherwise battery threshold settings apply to every
+detected power supply that supports them.
+
+Supported power fields:
+
+- `power.for`: list of power supply names
+- `power.charge-threshold-start`: percentage where charging starts
+- `power.charge-threshold-end`: percentage where charging stops
+- `power.platform-profile`: global ACPI platform profile string
+
+```toml
+[[rule]]
+if = "?discharging"
+priority = 20
+
+power.platform-profile = { first-available-platform-profile = ["low-power", "quiet"] }
+power.charge-threshold-start = 40
+power.charge-threshold-end = 80
+```
+
+Battery thresholds are hardware-sensitive. Watt supports common Linux power
+supply threshold paths used by Lenovo, ASUS, Huawei, Framework and devices using
+the standard `power_supply` API.
+
+## Intel Uncore Actions
+
+Uncore actions go under `uncore`. They apply to Intel uncore frequency devices
+under `/sys/devices/system/cpu/intel_uncore_frequency`.
+
+Supported uncore fields:
+
+- `uncore.for`: list of uncore device names
+- `uncore.frequency-khz-minimum`: minimum uncore frequency in kHz
+- `uncore.frequency-khz-maximum`: maximum uncore frequency in kHz
+
+```toml
+[[rule]]
+priority = 5
+uncore.frequency-khz-maximum = 4000000
+```
+
+## VM Memory Actions
+
+VM memory actions go under `vm`. Here, VM means Linux virtual memory, not a
+virtualized machine. Dirty bytes and dirty ratios are mutually exclusive pairs,
+matching the kernel sysctl behavior.
+
+Supported VM fields:
+
+- `vm.dirty-bytes`
+- `vm.dirty-ratio`
+- `vm.dirty-background-bytes`
+- `vm.dirty-background-ratio`
+- `vm.transparent-hugepages`: `"always"`, `"madvise"` or `"never"`
+- `vm.transparent-hugepage-defrag`: `"always"`, `"defer"`, `"defer+madvise"`,
+  `"madvise"` or `"never"`
+
+```toml
+[[rule]]
+priority = 10
+
+vm.dirty-ratio = 30
+vm.dirty-background-ratio = 10
+vm.transparent-hugepages = "madvise"
+```
+
+## Disk Actions
+
+Disk actions go under `disk`. Use `disk.for` to target block device names such
+as `sda` or `nvme0n1`; otherwise per-disk settings apply to all detected
+non-loop, non-removable block devices.
+
+Supported disk fields:
+
+- `disk.for`: list of disk names
+- `disk.scheduler`: block I/O scheduler string
+- `disk.readahead-kib`: read-ahead size in KiB
+- `disk.apm`: drive Advanced Power Management value passed to `hdparm -B`
+- `disk.spindown`: drive spindown timeout passed to `hdparm -S`
+- `disk.alpm`: global SATA ALPM policy for SCSI hosts
+
+Watt skips SATA ALPM writes on AHCI ports reported as external or
+hotplug-capable to preserve reliable hotplug removal detection.
+
+```toml
+[[rule]]
+if = "?discharging"
+priority = 25
+
+disk.readahead-kib = 4096
+disk.alpm = "med_power_with_dipm"
+```
+
+`disk.apm` and `disk.spindown` require `hdparm` and compatible drives. Watt only
+invokes `hdparm` if those fields are configured.
+
+## USB Actions
+
+USB actions go under `usb`. Use `usb.for` to target USB sysfs device names such
+as `1-1`; otherwise settings apply to all detected USB devices with power
+control files.
+
+Supported USB fields:
+
+- `usb.for`: list of USB device names
+- `usb.autosuspend`: boolean; `true` writes `auto`, `false` writes `on`
+- `usb.autosuspend-delay-seconds`: autosuspend delay in seconds
+
+```toml
+[[rule]]
+if = "?discharging"
+priority = 20
+
+usb.autosuspend = true
+usb.autosuspend-delay-seconds = 2
+```
+
+## Audio Actions
+
+Audio actions go under `audio`. They target supported module parameters for
+`snd_hda_intel` and `snd_ac97_codec` when those modules expose the relevant
+sysfs parameters.
+
+Supported audio fields:
+
+- `audio.timeout-seconds`: codec power-save timeout
+- `audio.reset-controller`: boolean controller reset policy
+
+```toml
+[[rule]]
+if = "?discharging"
+priority = 20
+
+audio.timeout-seconds = 10
+audio.reset-controller = true
+```
+
+## GPU Actions
+
+GPU actions go under `gpu`. Use `gpu.for` to target DRM card names such as
+`card0`; otherwise GPU settings apply to detected DRM cards with supported AMD
+power files.
+
+Supported GPU fields:
+
+- `gpu.for`: list of DRM card names
+- `gpu.panel-power-savings`: AMDGPU panel power savings level from `0` to `4`
+- `gpu.radeon-powersave`: Radeon power mode string
+
+Supported `gpu.radeon-powersave` values are `default`, `auto`, `low`, `mid`,
+`high`, `dynpm`, `dpm-battery`, `dpm-balanced` and `dpm-performance`.
+
+```toml
+[[rule]]
+if.all = ["?discharging", { is-chassis-type = "laptop" }]
+priority = 20
+
+gpu.panel-power-savings = 3
+```
+
+## Targeting Summary
+
+Sections with selectors:
+
+- `cpu.for`: CPU numbers
+- `power.for`: power supply names
+- `uncore.for`: Intel uncore device names
+- `disk.for`: block device names
+- `usb.for`: USB sysfs device names
+- `gpu.for`: DRM card names
+
+Sections without selectors apply globally or to their known supported targets:
+
+- `vm`
+- `audio`
+- `disk.alpm`
+- `power.platform-profile`
+
+## Compatibility Notes
+
+Most Watt settings write to Linux sysfs, procfs or device files and require root
+privileges. Unsupported hardware usually appears as a missing sysfs file, an
+unavailable predicate or an apply-time error from the kernel.
+
+Availability helpers are preferred for portable configs:
+
+```toml
+cpu.governor = { first-available-governor = ["schedutil", "powersave"] }
+power.platform-profile = { first-available-platform-profile = ["balanced", "low-power"] }
+cpu.turbo = { if = "?turbo-available", then = false }
+```

--- a/watt/audio.rs
+++ b/watt/audio.rs
@@ -1,0 +1,57 @@
+use anyhow::Context;
+
+use crate::fs;
+
+const AUDIO_MODULES: &[&str] = &["snd_hda_intel", "snd_ac97_codec"];
+
+#[derive(Default, Debug, Clone, PartialEq)]
+#[must_use]
+pub struct Delta {
+  pub timeout_seconds:  Option<u64>,
+  pub reset_controller: Option<bool>,
+}
+
+impl Delta {
+  pub fn is_some(&self) -> bool {
+    self.timeout_seconds.is_some() && self.reset_controller.is_some()
+  }
+
+  pub fn or(self, that: &Self) -> Self {
+    Self {
+      timeout_seconds:  self.timeout_seconds.or(that.timeout_seconds),
+      reset_controller: self.reset_controller.or(that.reset_controller),
+    }
+  }
+
+  pub fn apply(&self) -> anyhow::Result<()> {
+    for module in AUDIO_MODULES {
+      if let Some(timeout) = self.timeout_seconds {
+        write_if_exists(module, "power_save", &timeout.to_string())?;
+      }
+      if let Some(reset) = self.reset_controller {
+        write_if_exists(
+          module,
+          "power_save_controller",
+          if reset { "Y" } else { "N" },
+        )?;
+      }
+    }
+
+    Ok(())
+  }
+}
+
+fn write_if_exists(
+  module: &str,
+  parameter: &str,
+  value: &str,
+) -> anyhow::Result<()> {
+  let path = format!("/sys/module/{module}/parameters/{parameter}");
+  if fs::exists(&path) {
+    fs::write(&path, value).with_context(|| {
+      format!("failed to set audio module parameter '{path}'")
+    })?;
+  }
+
+  Ok(())
+}

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -20,10 +20,14 @@ use serde::{
 };
 
 use crate::{
+  audio,
   cpu,
+  disk,
+  gpu,
   power_supply,
   system,
   uncore,
+  usb,
   vm,
 };
 
@@ -34,6 +38,9 @@ type PowerSupplyDeltas =
 type PowerSupplyEvalResult =
   anyhow::Result<(PowerSupplyDeltas, Option<String>)>;
 type UncoreDeltas = HashMap<Arc<uncore::Uncore>, uncore::Delta>;
+type DiskDeltas = HashMap<Arc<disk::Disk>, disk::Delta>;
+type UsbDeltas = HashMap<Arc<usb::UsbDevice>, usb::Delta>;
+type GpuDeltas = HashMap<Arc<gpu::Gpu>, gpu::Delta>;
 
 fn is_default<T: Default + PartialEq>(value: &T) -> bool {
   *value == T::default()
@@ -460,6 +467,230 @@ impl VmDelta {
   }
 }
 
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields, default, rename_all = "kebab-case")]
+pub struct DisksDelta {
+  #[serde(rename = "for", skip_serializing_if = "is_default")]
+  pub for_:          Option<Expression>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub scheduler:     Option<Expression>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub readahead_kib: Option<Expression>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub apm:           Option<Expression>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub spindown:      Option<Expression>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub alpm:          Option<Expression>,
+}
+
+impl DisksDelta {
+  pub fn eval(
+    &self,
+    state: &EvalState<'_, '_>,
+  ) -> anyhow::Result<(DiskDeltas, disk::GlobalDelta)> {
+    let disks = match &self.for_ {
+      Some(names) => {
+        let names = names
+          .eval(state)?
+          .context("`disk.for` resolved to undefined")?;
+        let names =
+          names.try_into_list().context("`disk.for` was not a list")?;
+
+        let names = names
+          .into_iter()
+          .map(|name| name.try_into_string())
+          .collect::<anyhow::Result<Vec<_>>>()?;
+
+        state
+          .disks
+          .iter()
+          .filter(|disk| names.contains(&disk.name))
+          .cloned()
+          .collect()
+      },
+      None => state.disks.clone(),
+    };
+
+    let apm = eval_u8(&self.apm, state, "disk.apm")?;
+    let spindown = eval_u8(&self.spindown, state, "disk.spindown")?;
+    let mut deltas = HashMap::with_capacity(disks.len());
+
+    for disk in disks {
+      deltas.insert(Arc::clone(&disk), disk::Delta {
+        scheduler: eval_string(&self.scheduler, state, "disk.scheduler")?,
+        readahead_kib: eval_u64(
+          &self.readahead_kib,
+          state,
+          "disk.readahead-kib",
+        )?,
+        apm,
+        spindown,
+      });
+    }
+
+    Ok((deltas, disk::GlobalDelta {
+      alpm: eval_string(&self.alpm, state, "disk.alpm")?,
+    }))
+  }
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields, default, rename_all = "kebab-case")]
+pub struct UsbsDelta {
+  #[serde(rename = "for", skip_serializing_if = "is_default")]
+  pub for_:                      Option<Expression>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub autosuspend:               Option<Expression>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub autosuspend_delay_seconds: Option<Expression>,
+}
+
+impl UsbsDelta {
+  pub fn eval(&self, state: &EvalState<'_, '_>) -> anyhow::Result<UsbDeltas> {
+    let devices = match &self.for_ {
+      Some(names) => {
+        let names = names
+          .eval(state)?
+          .context("`usb.for` resolved to undefined")?
+          .try_into_list()
+          .context("`usb.for` was not a list")?;
+        let names = names
+          .into_iter()
+          .map(|name| name.try_into_string())
+          .collect::<anyhow::Result<Vec<_>>>()?;
+
+        state
+          .usb_devices
+          .iter()
+          .filter(|device| names.contains(&device.name))
+          .cloned()
+          .collect()
+      },
+      None => state.usb_devices.clone(),
+    };
+
+    let delay_ms = eval_u64(
+      &self.autosuspend_delay_seconds,
+      state,
+      "usb.autosuspend-delay-seconds",
+    )?
+    .map(|seconds| {
+      seconds.checked_mul(1000).with_context(|| {
+        "`usb.autosuspend-delay-seconds` is too large to convert to \
+         milliseconds"
+      })
+    })
+    .transpose()?;
+    let mut deltas = HashMap::with_capacity(devices.len());
+
+    for device in devices {
+      deltas.insert(Arc::clone(&device), usb::Delta {
+        autosuspend:          eval_bool(
+          &self.autosuspend,
+          state,
+          "usb.autosuspend",
+        )?,
+        autosuspend_delay_ms: delay_ms,
+      });
+    }
+
+    Ok(deltas)
+  }
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields, default, rename_all = "kebab-case")]
+pub struct AudioDelta {
+  #[serde(skip_serializing_if = "is_default")]
+  pub timeout_seconds:  Option<Expression>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub reset_controller: Option<Expression>,
+}
+
+impl AudioDelta {
+  pub fn eval(
+    &self,
+    state: &EvalState<'_, '_>,
+  ) -> anyhow::Result<audio::Delta> {
+    Ok(audio::Delta {
+      timeout_seconds:  eval_u64(
+        &self.timeout_seconds,
+        state,
+        "audio.timeout-seconds",
+      )?,
+      reset_controller: eval_bool(
+        &self.reset_controller,
+        state,
+        "audio.reset-controller",
+      )?,
+    })
+  }
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields, default, rename_all = "kebab-case")]
+pub struct GpusDelta {
+  #[serde(rename = "for", skip_serializing_if = "is_default")]
+  pub for_:                Option<Expression>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub panel_power_savings: Option<Expression>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub radeon_powersave:    Option<Expression>,
+}
+
+impl GpusDelta {
+  pub fn eval(&self, state: &EvalState<'_, '_>) -> anyhow::Result<GpuDeltas> {
+    let gpus = match &self.for_ {
+      Some(names) => {
+        let names = names
+          .eval(state)?
+          .context("`gpu.for` resolved to undefined")?
+          .try_into_list()
+          .context("`gpu.for` was not a list")?;
+        let names = names
+          .into_iter()
+          .map(|name| name.try_into_string())
+          .collect::<anyhow::Result<Vec<_>>>()?;
+
+        state
+          .gpus
+          .iter()
+          .filter(|gpu| names.contains(&gpu.name))
+          .cloned()
+          .collect()
+      },
+      None => state.gpus.clone(),
+    };
+
+    let panel_power_savings = eval_percent(
+      &self.panel_power_savings,
+      state,
+      "gpu.panel-power-savings",
+    )?;
+    if let Some(value) = panel_power_savings
+      && value > 4
+    {
+      bail!("`gpu.panel-power-savings` must be between 0 and 4, got {value}");
+    }
+
+    let mut deltas = HashMap::with_capacity(gpus.len());
+
+    for gpu in gpus {
+      deltas.insert(Arc::clone(&gpu), gpu::Delta {
+        panel_power_savings,
+        radeon_powersave: eval_string(
+          &self.radeon_powersave,
+          state,
+          "gpu.radeon-powersave",
+        )?,
+      });
+    }
+
+    Ok(deltas)
+  }
+}
+
 fn eval_u32(
   expression: &Option<Expression>,
   state: &EvalState<'_, '_>,
@@ -507,7 +738,6 @@ fn eval_u8(
 
   Ok(Some(value as u8))
 }
-
 fn eval_u64(
   expression: &Option<Expression>,
   state: &EvalState<'_, '_>,
@@ -546,6 +776,24 @@ fn eval_string(
   value
     .try_into_string()
     .with_context(|| format!("`{name}` was not a string"))
+    .map(Some)
+}
+
+fn eval_bool(
+  expression: &Option<Expression>,
+  state: &EvalState<'_, '_>,
+  name: &str,
+) -> anyhow::Result<Option<bool>> {
+  let Some(expression) = expression else {
+    return Ok(None);
+  };
+  let Some(value) = expression.eval(state)? else {
+    return Ok(None);
+  };
+
+  value
+    .try_into_boolean()
+    .with_context(|| format!("`{name}` was not a boolean"))
     .map(Some)
 }
 
@@ -1050,6 +1298,9 @@ pub struct EvalState<'peripherals, 'context> {
 
   pub cpus:           &'peripherals HashSet<Arc<cpu::Cpu>>,
   pub uncores:        &'peripherals HashSet<Arc<uncore::Uncore>>,
+  pub disks:          &'peripherals HashSet<Arc<disk::Disk>>,
+  pub usb_devices:    &'peripherals HashSet<Arc<usb::UsbDevice>>,
+  pub gpus:           &'peripherals HashSet<Arc<gpu::Gpu>>,
   pub power_supplies: &'peripherals HashSet<Arc<power_supply::PowerSupply>>,
   pub cpu_log:        &'peripherals VecDeque<system::CpuLog>,
 }
@@ -1535,6 +1786,14 @@ pub struct Rule {
   #[serde(default, skip_serializing_if = "is_default")]
   pub vm:     VmDelta,
   #[serde(default, skip_serializing_if = "is_default")]
+  pub disk:   DisksDelta,
+  #[serde(default, skip_serializing_if = "is_default")]
+  pub usb:    UsbsDelta,
+  #[serde(default, skip_serializing_if = "is_default")]
+  pub audio:  AudioDelta,
+  #[serde(default, skip_serializing_if = "is_default")]
+  pub gpu:    GpusDelta,
+  #[serde(default, skip_serializing_if = "is_default")]
   pub power:  PowersDelta,
 }
 
@@ -1547,6 +1806,10 @@ impl Default for Rule {
       cpu:       CpusDelta::default(),
       uncore:    UncoresDelta::default(),
       vm:        VmDelta::default(),
+      disk:      DisksDelta::default(),
+      usb:       UsbsDelta::default(),
+      audio:     AudioDelta::default(),
+      gpu:       GpusDelta::default(),
       power:     PowersDelta::default(),
     }
   }
@@ -1697,6 +1960,9 @@ mod tests {
 
       let power_supplies = HashSet::new();
       let uncores = HashSet::new();
+      let disks = HashSet::new();
+      let usb_devices = HashSet::new();
+      let gpus = HashSet::new();
       let cpu_log = VecDeque::new();
 
       // Create an eval state with the base frequency
@@ -1720,6 +1986,9 @@ mod tests {
         context: EvalContext::Cpu(&cpu),
         cpus: &cpus,
         uncores: &uncores,
+        disks: &disks,
+        usb_devices: &usb_devices,
+        gpus: &gpus,
         power_supplies: &power_supplies,
         cpu_log: &cpu_log,
       };
@@ -1795,6 +2064,9 @@ mod tests {
 
     let power_supplies = HashSet::new();
     let uncores = HashSet::new();
+    let disks = HashSet::new();
+    let usb_devices = HashSet::new();
+    let gpus = HashSet::new();
     let cpu_log = VecDeque::new();
 
     let state = EvalState {
@@ -1817,6 +2089,9 @@ mod tests {
       context:                     EvalContext::Cpu(&cpu),
       cpus:                        &cpus,
       uncores:                     &uncores,
+      disks:                       &disks,
+      usb_devices:                 &usb_devices,
+      gpus:                        &gpus,
       power_supplies:              &power_supplies,
       cpu_log:                     &cpu_log,
     };
@@ -1880,6 +2155,9 @@ mod tests {
 
     let power_supplies = HashSet::new();
     let uncores = HashSet::new();
+    let disks = HashSet::new();
+    let usb_devices = HashSet::new();
+    let gpus = HashSet::new();
     let cpu_log = VecDeque::new();
 
     let state = EvalState {
@@ -1902,6 +2180,9 @@ mod tests {
       context:                     EvalContext::Cpu(&cpu),
       cpus:                        &cpus,
       uncores:                     &uncores,
+      disks:                       &disks,
+      usb_devices:                 &usb_devices,
+      gpus:                        &gpus,
       power_supplies:              &power_supplies,
       cpu_log:                     &cpu_log,
     };
@@ -1952,6 +2233,9 @@ mod tests {
 
     let power_supplies = HashSet::new();
     let uncores = HashSet::new();
+    let disks = HashSet::new();
+    let usb_devices = HashSet::new();
+    let gpus = HashSet::new();
     let cpu_log = VecDeque::new();
 
     let state = EvalState {
@@ -1974,6 +2258,9 @@ mod tests {
       context:                     EvalContext::Cpu(&cpu),
       cpus:                        &cpus,
       uncores:                     &uncores,
+      disks:                       &disks,
+      usb_devices:                 &usb_devices,
+      gpus:                        &gpus,
       power_supplies:              &power_supplies,
       cpu_log:                     &cpu_log,
     };

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -456,6 +456,24 @@ pub enum Expression {
     #[serde(rename = "is-platform-profile-available")]
     value: Box<Expression>,
   },
+
+  FirstAvailableGovernor {
+    #[serde(rename = "first-available-governor")]
+    values: Vec<Expression>,
+  },
+  FirstAvailableEnergyPerformancePreference {
+    #[serde(rename = "first-available-energy-performance-preference")]
+    values: Vec<Expression>,
+  },
+  FirstAvailableEnergyPerfBias {
+    #[serde(rename = "first-available-energy-perf-bias")]
+    values: Vec<Expression>,
+  },
+  FirstAvailablePlatformProfile {
+    #[serde(rename = "first-available-platform-profile")]
+    values: Vec<Expression>,
+  },
+
   IsDriverLoaded {
     #[serde(rename = "is-driver-loaded")]
     value: Box<Expression>,
@@ -760,6 +778,46 @@ impl Expression {
       };
     }
 
+    fn eval_string_list(
+      values: &[Expression],
+      state: &EvalState<'_, '_>,
+      name: &str,
+    ) -> anyhow::Result<Option<Vec<std::string::String>>> {
+      let mut strings = Vec::with_capacity(values.len());
+
+      for value in values {
+        let Some(value) = value.eval(state)? else {
+          return Ok(None);
+        };
+
+        strings.push(
+          value
+            .try_into_string()
+            .with_context(|| format!("`{name}` item was not a string"))?,
+        );
+      }
+
+      Ok(Some(strings))
+    }
+
+    fn first_available_cpu_value(
+      state: &EvalState<'_, '_>,
+      values: &[std::string::String],
+      available: impl Fn(&cpu::Cpu) -> &[std::string::String],
+    ) -> Option<std::string::String> {
+      values.iter().find_map(|value| {
+        let is_available = match state.context {
+          EvalContext::Cpu(cpu) => available(cpu).contains(value),
+          EvalContext::PowerSupply(_) => false,
+          EvalContext::WidestPossible => {
+            state.cpus.iter().any(|cpu| available(cpu).contains(value))
+          },
+        };
+
+        is_available.then(|| value.clone())
+      })
+    }
+
     Ok(Some(match self {
       IsGovernorAvailable { value } => {
         let value = eval!(value);
@@ -825,6 +883,60 @@ impl Expression {
             .contains(&value);
 
         Boolean(available)
+      },
+      FirstAvailableGovernor { values } => {
+        let Some(values) =
+          eval_string_list(values, state, "first-available-governor")?
+        else {
+          return Ok(None);
+        };
+
+        String(try_ok!(first_available_cpu_value(state, &values, |cpu| {
+          &cpu.available_governors
+        },)))
+      },
+      FirstAvailableEnergyPerformancePreference { values } => {
+        let Some(values) = eval_string_list(
+          values,
+          state,
+          "first-available-energy-performance-preference",
+        )?
+        else {
+          return Ok(None);
+        };
+
+        String(try_ok!(first_available_cpu_value(state, &values, |cpu| {
+          &cpu.available_epps
+        },)))
+      },
+      FirstAvailableEnergyPerfBias { values } => {
+        let Some(values) =
+          eval_string_list(values, state, "first-available-energy-perf-bias")?
+        else {
+          return Ok(None);
+        };
+
+        String(try_ok!(first_available_cpu_value(state, &values, |cpu| {
+          &cpu.available_epbs
+        },)))
+      },
+      FirstAvailablePlatformProfile { values } => {
+        let Some(values) =
+          eval_string_list(values, state, "first-available-platform-profile")?
+        else {
+          return Ok(None);
+        };
+
+        let available =
+          power_supply::PowerSupply::get_available_platform_profiles()
+            .context(
+              "failed to get available platform profiles for \
+               `first-available-platform-profile`",
+            )?;
+
+        String(try_ok!(
+          values.into_iter().find(|value| available.contains(value))
+        ))
       },
       IsDriverLoaded { value } => {
         let value = eval!(value).try_into_string()?;
@@ -1475,5 +1587,69 @@ mod tests {
       result.is_ok() && result.as_ref().unwrap().is_none(),
       "CpuTemperatureVolatility should return None with insufficient data"
     );
+  }
+
+  #[test]
+  fn first_available_governor_selects_first_supported_value() {
+    let cpu = Arc::new(cpu::Cpu {
+      number:                0,
+      has_cpufreq:           true,
+      available_governors:   vec![
+        "powersave".to_owned(),
+        "schedutil".to_owned(),
+      ],
+      governor:              None,
+      frequency_mhz:         Some(3333),
+      frequency_mhz_minimum: Some(1000),
+      frequency_mhz_maximum: Some(3333),
+      available_epps:        vec![],
+      epp:                   None,
+      available_epbs:        vec![],
+      epb:                   None,
+      stat:                  cpu::CpuStat::default(),
+      previous_stat:         None,
+      info:                  None,
+    });
+
+    let mut cpus = HashSet::new();
+    cpus.insert(cpu.clone());
+
+    let power_supplies = HashSet::new();
+    let cpu_log = VecDeque::new();
+
+    let state = EvalState {
+      frequency_available:         true,
+      turbo_available:             false,
+      cpu_usage:                   0.0,
+      cpu_usage_volatility:        None,
+      cpu_temperature:             None,
+      cpu_temperature_volatility:  None,
+      cpu_idle_seconds:            0.0,
+      cpu_frequency_maximum:       Some(3333.0),
+      cpu_frequency_minimum:       Some(1000.0),
+      lid_closed:                  false,
+      power_supply_charge:         None,
+      power_supply_discharge_rate: None,
+      battery_cycles:              None,
+      battery_health:              None,
+      discharging:                 false,
+      power_profile_preference:    crate::profile::PowerProfile::Balanced,
+      context:                     EvalContext::Cpu(&cpu),
+      cpus:                        &cpus,
+      power_supplies:              &power_supplies,
+      cpu_log:                     &cpu_log,
+    };
+
+    let result = Expression::FirstAvailableGovernor {
+      values: vec![
+        Expression::String("performance".to_owned()),
+        Expression::String("schedutil".to_owned()),
+        Expression::String("powersave".to_owned()),
+      ],
+    }
+    .eval(&state)
+    .unwrap();
+
+    assert_eq!(result, Some(Expression::String("schedutil".to_owned())));
   }
 }

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -23,6 +23,7 @@ use crate::{
   cpu,
   power_supply,
   system,
+  uncore,
 };
 
 type CpuDeltas = HashMap<Arc<cpu::Cpu>, cpu::Delta>;
@@ -31,6 +32,7 @@ type PowerSupplyDeltas =
   HashMap<Arc<power_supply::PowerSupply>, power_supply::Delta>;
 type PowerSupplyEvalResult =
   anyhow::Result<(PowerSupplyDeltas, Option<String>)>;
+type UncoreDeltas = HashMap<Arc<uncore::Uncore>, uncore::Delta>;
 
 fn is_default<T: Default + PartialEq>(value: &T) -> bool {
   *value == T::default()
@@ -315,6 +317,88 @@ impl CpusDelta {
     };
 
     Ok((deltas, global))
+  }
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields, default, rename_all = "kebab-case")]
+pub struct UncoresDelta {
+  /// The uncore devices to apply the changes to. When unspecified, will be
+  /// applied to all uncore devices.
+  ///
+  /// Type: `Vec<String>`.
+  #[serde(rename = "for", skip_serializing_if = "is_default")]
+  pub for_: Option<Expression>,
+
+  /// Set minimum uncore frequency in kHz.
+  ///
+  /// Type: `u64`.
+  #[serde(skip_serializing_if = "is_default")]
+  pub frequency_khz_minimum: Option<Expression>,
+
+  /// Set maximum uncore frequency in kHz.
+  ///
+  /// Type: `u64`.
+  #[serde(skip_serializing_if = "is_default")]
+  pub frequency_khz_maximum: Option<Expression>,
+}
+
+impl UncoresDelta {
+  pub fn eval(
+    &self,
+    state: &EvalState<'_, '_>,
+  ) -> anyhow::Result<UncoreDeltas> {
+    log::debug!("evaluating uncore deltas...");
+
+    let uncores = match &self.for_ {
+      Some(names) => {
+        let names = names
+          .eval(state)?
+          .context("`uncore.for` resolved to undefined")?;
+        let names = names
+          .try_into_list()
+          .context("`uncore.for` was not a list")?;
+
+        let mut uncores = Vec::with_capacity(names.len());
+
+        for name in names {
+          let name = name
+            .try_into_string()
+            .context("`uncore.for` item was not a string")?;
+
+          uncores.push(name);
+        }
+
+        state
+          .uncores
+          .iter()
+          .filter(|uncore| uncores.contains(&uncore.name))
+          .cloned()
+          .collect()
+      },
+      None => state.uncores.clone(),
+    };
+
+    let mut deltas = HashMap::with_capacity(uncores.len());
+
+    for uncore in uncores {
+      let delta = uncore::Delta {
+        frequency_khz_minimum: eval_u64(
+          &self.frequency_khz_minimum,
+          state,
+          "uncore.frequency-khz-minimum",
+        )?,
+        frequency_khz_maximum: eval_u64(
+          &self.frequency_khz_maximum,
+          state,
+          "uncore.frequency-khz-maximum",
+        )?,
+      };
+
+      deltas.insert(Arc::clone(&uncore), delta);
+    }
+
+    Ok(deltas)
   }
 }
 
@@ -889,6 +973,7 @@ pub struct EvalState<'peripherals, 'context> {
   pub context: EvalContext<'context>,
 
   pub cpus:           &'peripherals HashSet<Arc<cpu::Cpu>>,
+  pub uncores:        &'peripherals HashSet<Arc<uncore::Uncore>>,
   pub power_supplies: &'peripherals HashSet<Arc<power_supply::PowerSupply>>,
   pub cpu_log:        &'peripherals VecDeque<system::CpuLog>,
 }
@@ -1368,9 +1453,11 @@ pub struct Rule {
   pub condition: Expression,
 
   #[serde(default, skip_serializing_if = "is_default")]
-  pub cpu:   CpusDelta,
+  pub cpu:    CpusDelta,
   #[serde(default, skip_serializing_if = "is_default")]
-  pub power: PowersDelta,
+  pub uncore: UncoresDelta,
+  #[serde(default, skip_serializing_if = "is_default")]
+  pub power:  PowersDelta,
 }
 
 impl Default for Rule {
@@ -1380,6 +1467,7 @@ impl Default for Rule {
       priority:  u16::default(),
       condition: literal_true(),
       cpu:       CpusDelta::default(),
+      uncore:    UncoresDelta::default(),
       power:     PowersDelta::default(),
     }
   }
@@ -1529,6 +1617,7 @@ mod tests {
       cpus.insert(cpu.clone());
 
       let power_supplies = HashSet::new();
+      let uncores = HashSet::new();
       let cpu_log = VecDeque::new();
 
       // Create an eval state with the base frequency
@@ -1551,6 +1640,7 @@ mod tests {
         power_profile_preference: crate::profile::PowerProfile::Balanced,
         context: EvalContext::Cpu(&cpu),
         cpus: &cpus,
+        uncores: &uncores,
         power_supplies: &power_supplies,
         cpu_log: &cpu_log,
       };
@@ -1625,6 +1715,7 @@ mod tests {
     cpus.insert(cpu.clone());
 
     let power_supplies = HashSet::new();
+    let uncores = HashSet::new();
     let cpu_log = VecDeque::new();
 
     let state = EvalState {
@@ -1646,6 +1737,7 @@ mod tests {
       power_profile_preference:    crate::profile::PowerProfile::Balanced,
       context:                     EvalContext::Cpu(&cpu),
       cpus:                        &cpus,
+      uncores:                     &uncores,
       power_supplies:              &power_supplies,
       cpu_log:                     &cpu_log,
     };
@@ -1708,6 +1800,7 @@ mod tests {
     cpus.insert(cpu.clone());
 
     let power_supplies = HashSet::new();
+    let uncores = HashSet::new();
     let cpu_log = VecDeque::new();
 
     let state = EvalState {
@@ -1729,6 +1822,7 @@ mod tests {
       power_profile_preference:    crate::profile::PowerProfile::Balanced,
       context:                     EvalContext::Cpu(&cpu),
       cpus:                        &cpus,
+      uncores:                     &uncores,
       power_supplies:              &power_supplies,
       cpu_log:                     &cpu_log,
     };
@@ -1778,6 +1872,7 @@ mod tests {
     cpus.insert(cpu.clone());
 
     let power_supplies = HashSet::new();
+    let uncores = HashSet::new();
     let cpu_log = VecDeque::new();
 
     let state = EvalState {
@@ -1799,6 +1894,7 @@ mod tests {
       power_profile_preference:    crate::profile::PowerProfile::Balanced,
       context:                     EvalContext::Cpu(&cpu),
       cpus:                        &cpus,
+      uncores:                     &uncores,
       power_supplies:              &power_supplies,
       cpu_log:                     &cpu_log,
     };

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -986,6 +986,7 @@ mod expression {
   named!(cpu_core_count => "%cpu-core-count");
 
   named!(lid_closed => "?lid-closed");
+  named!(virtual_machine => "?virtual-machine");
 
   named!(hour_of_day => "$hour-of-day");
 
@@ -1017,6 +1018,10 @@ pub enum Expression {
   },
   IsPlatformProfileAvailable {
     #[serde(rename = "is-platform-profile-available")]
+    value: Box<Expression>,
+  },
+  IsChassisType {
+    #[serde(rename = "is-chassis-type")]
     value: Box<Expression>,
   },
 
@@ -1092,6 +1097,9 @@ pub enum Expression {
 
   #[serde(with = "expression::lid_closed")]
   LidClosed,
+
+  #[serde(with = "expression::virtual_machine")]
+  VirtualMachine,
 
   #[serde(with = "expression::hour_of_day")]
   HourOfDay,
@@ -1282,7 +1290,9 @@ pub struct EvalState<'peripherals, 'context> {
   pub cpu_frequency_maximum:      Option<f64>,
   pub cpu_frequency_minimum:      Option<f64>,
 
-  pub lid_closed: bool,
+  pub lid_closed:      bool,
+  pub virtual_machine: bool,
+  pub chassis_type:    Option<&'peripherals str>,
 
   pub power_supply_charge:         Option<f64>,
   pub power_supply_discharge_rate: Option<f64>,
@@ -1451,6 +1461,11 @@ impl Expression {
 
         Boolean(available)
       },
+      IsChassisType { value } => {
+        let value = eval!(value).try_into_string()?;
+
+        Boolean(state.chassis_type == Some(value.as_str()))
+      },
       FirstAvailableGovernor { values } => {
         let Some(values) =
           eval_string_list(values, state, "first-available-governor")?
@@ -1590,6 +1605,7 @@ impl Expression {
       },
 
       LidClosed => Boolean(state.lid_closed),
+      VirtualMachine => Boolean(state.virtual_machine),
 
       HourOfDay => {
         let ts = jiff::Timestamp::now()
@@ -1977,6 +1993,8 @@ mod tests {
         cpu_frequency_maximum: Some(base_freq as f64),
         cpu_frequency_minimum: Some(1000.0),
         lid_closed: false,
+        virtual_machine: false,
+        chassis_type: None,
         power_supply_charge: Some(0.8),
         power_supply_discharge_rate: Some(10.0),
         battery_cycles: Some(100.0),
@@ -2080,6 +2098,8 @@ mod tests {
       cpu_frequency_maximum:       Some(3333.0),
       cpu_frequency_minimum:       Some(1000.0),
       lid_closed:                  false,
+      virtual_machine:             false,
+      chassis_type:                None,
       power_supply_charge:         Some(0.8),
       power_supply_discharge_rate: Some(10.0),
       battery_cycles:              Some(100.0),
@@ -2171,6 +2191,8 @@ mod tests {
       cpu_frequency_maximum:       Some(3333.0),
       cpu_frequency_minimum:       Some(1000.0),
       lid_closed:                  false,
+      virtual_machine:             false,
+      chassis_type:                None,
       power_supply_charge:         None,
       power_supply_discharge_rate: None,
       battery_cycles:              None,
@@ -2249,6 +2271,8 @@ mod tests {
       cpu_frequency_maximum:       Some(3333.0),
       cpu_frequency_minimum:       Some(1000.0),
       lid_closed:                  false,
+      virtual_machine:             false,
+      chassis_type:                None,
       power_supply_charge:         None,
       power_supply_discharge_rate: None,
       battery_cycles:              None,

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 
 type CpuDeltas = HashMap<Arc<cpu::Cpu>, cpu::Delta>;
-type CpuEvalResult = anyhow::Result<(CpuDeltas, Option<bool>)>;
+type CpuEvalResult = anyhow::Result<(CpuDeltas, cpu::GlobalDelta)>;
 type PowerSupplyDeltas =
   HashMap<Arc<power_supply::PowerSupply>, power_supply::Delta>;
 type PowerSupplyEvalResult =
@@ -106,6 +106,30 @@ pub struct CpusDelta {
   /// Type: `bool`.
   #[serde(skip_serializing_if = "is_default")]
   pub turbo: Option<Expression>,
+
+  /// Set Intel P-State minimum performance as a percentage.
+  ///
+  /// Type: `u8`.
+  #[serde(skip_serializing_if = "is_default")]
+  pub pstate_min_performance_percent: Option<Expression>,
+
+  /// Set Intel P-State maximum performance as a percentage.
+  ///
+  /// Type: `u8`.
+  #[serde(skip_serializing_if = "is_default")]
+  pub pstate_max_performance_percent: Option<Expression>,
+
+  /// Set the system-wide PM QoS DMA latency request in microseconds.
+  ///
+  /// Type: `i32`.
+  #[serde(skip_serializing_if = "is_default")]
+  pub dma_latency_us: Option<Expression>,
+
+  /// Set per-CPU PM QoS resume latency in microseconds, or `n/a`.
+  ///
+  /// Type: `u32 | String`.
+  #[serde(skip_serializing_if = "is_default")]
+  pub pm_qos_resume_latency_us: Option<Expression>,
 }
 
 impl CpusDelta {
@@ -230,10 +254,35 @@ impl CpusDelta {
         delta.frequency_mhz_maximum = Some(rounded_value);
       }
 
+      if let Some(pm_qos_resume_latency_us) = &self.pm_qos_resume_latency_us
+        && let Some(pm_qos_resume_latency_us) =
+          pm_qos_resume_latency_us.eval(&state)?
+      {
+        delta.pm_qos_resume_latency_us = Some(match pm_qos_resume_latency_us {
+          Expression::String(value) if value == "n/a" => value,
+          Expression::String(value) => {
+            bail!(
+              "invalid `cpu.pm-qos-resume-latency-us`: {value}; expected a \
+               non-negative integer or \"n/a\""
+            );
+          },
+          value => {
+            let value = value.try_into_number().context(
+              "`cpu.pm-qos-resume-latency-us` was not a number or string",
+            )?;
+
+            if value.fract() != 0.0 || value < 0.0 || value > u64::MAX as f64 {
+              bail!("invalid `cpu.pm-qos-resume-latency-us`: {value}");
+            }
+
+            (value as u64).to_string()
+          },
+        });
+      }
+
       deltas.insert(Arc::clone(&cpu), delta);
     }
 
-    // This is so bad lmao
     let turbo = if let Some(turbo) = &self.turbo
       && let Some(turbo) = turbo.eval(state)?
     {
@@ -246,8 +295,114 @@ impl CpusDelta {
       None
     };
 
-    Ok((deltas, turbo))
+    let global = cpu::GlobalDelta {
+      turbo,
+      pstate_min_performance_percent: eval_percent(
+        &self.pstate_min_performance_percent,
+        state,
+        "cpu.pstate-min-performance-percent",
+      )?,
+      pstate_max_performance_percent: eval_percent(
+        &self.pstate_max_performance_percent,
+        state,
+        "cpu.pstate-max-performance-percent",
+      )?,
+      dma_latency_us: eval_i32(
+        &self.dma_latency_us,
+        state,
+        "cpu.dma-latency-us",
+      )?,
+    };
+
+    Ok((deltas, global))
   }
+}
+
+fn eval_u32(
+  expression: &Option<Expression>,
+  state: &EvalState<'_, '_>,
+  name: &str,
+) -> anyhow::Result<Option<u32>> {
+  let Some(value) = eval_u64(expression, state, name)? else {
+    return Ok(None);
+  };
+
+  if value > u32::MAX as u64 {
+    bail!("invalid `{name}`: {value}");
+  }
+
+  Ok(Some(value as u32))
+}
+
+fn eval_i32(
+  expression: &Option<Expression>,
+  state: &EvalState<'_, '_>,
+  name: &str,
+) -> anyhow::Result<Option<i32>> {
+  let Some(value) = eval_u64(expression, state, name)? else {
+    return Ok(None);
+  };
+
+  if value > i32::MAX as u64 {
+    bail!("invalid `{name}`: {value}; maximum is {}", i32::MAX);
+  }
+
+  Ok(Some(value as i32))
+}
+
+fn eval_u8(
+  expression: &Option<Expression>,
+  state: &EvalState<'_, '_>,
+  name: &str,
+) -> anyhow::Result<Option<u8>> {
+  let Some(value) = eval_u64(expression, state, name)? else {
+    return Ok(None);
+  };
+
+  if value > u8::MAX as u64 {
+    bail!("invalid `{name}`: {value}");
+  }
+
+  Ok(Some(value as u8))
+}
+
+fn eval_u64(
+  expression: &Option<Expression>,
+  state: &EvalState<'_, '_>,
+  name: &str,
+) -> anyhow::Result<Option<u64>> {
+  let Some(expression) = expression else {
+    return Ok(None);
+  };
+  let Some(value) = expression.eval(state)? else {
+    return Ok(None);
+  };
+
+  let value = value
+    .try_into_number()
+    .with_context(|| format!("`{name}` was not a number"))?;
+
+  if value.fract() != 0.0 || value < 0.0 || value > u64::MAX as f64 {
+    bail!("invalid `{name}`: {value}");
+  }
+
+  Ok(Some(value as u64))
+}
+
+fn eval_percent(
+  expression: &Option<Expression>,
+  state: &EvalState<'_, '_>,
+  name: &str,
+) -> anyhow::Result<Option<u8>> {
+  let Some(value) = eval_u32(expression, state, name)? else {
+    return Ok(None);
+  };
+
+  if value > 100 {
+    bail!("`{name}` must be between 0 and 100, got {value}");
+  }
+
+  Ok(Some(value as u8))
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
@@ -1426,6 +1581,10 @@ mod tests {
           frequency_mhz_minimum: None,
           frequency_mhz_maximum: Some(Expression::Number(value)),
           turbo: None,
+          pstate_min_performance_percent: None,
+          pstate_max_performance_percent: None,
+          dma_latency_us: None,
+          pm_qos_resume_latency_us: None,
         };
 
         // Try to evaluate it - this should not panic after the fix
@@ -1493,16 +1652,20 @@ mod tests {
 
     // 3333 * 0.65 = 2166.45
     let cpu_delta = CpusDelta {
-      for_:                          None,
-      governor:                      None,
-      energy_performance_preference: None,
-      energy_perf_bias:              None,
-      frequency_mhz_minimum:         None,
-      frequency_mhz_maximum:         Some(Expression::Multiply {
+      for_:                           None,
+      governor:                       None,
+      energy_performance_preference:  None,
+      energy_perf_bias:               None,
+      frequency_mhz_minimum:          None,
+      frequency_mhz_maximum:          Some(Expression::Multiply {
         a: Box::new(Expression::CpuFrequencyMaximum),
         b: Box::new(Expression::Number(0.65)),
       }),
-      turbo:                         None,
+      turbo:                          None,
+      pstate_min_performance_percent: None,
+      pstate_max_performance_percent: None,
+      dma_latency_us:                 None,
+      pm_qos_resume_latency_us:       None,
     };
 
     // Previously this would bail! with "invalid number for ...". With the

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -24,6 +24,7 @@ use crate::{
   power_supply,
   system,
   uncore,
+  vm,
 };
 
 type CpuDeltas = HashMap<Arc<cpu::Cpu>, cpu::Delta>;
@@ -402,6 +403,63 @@ impl UncoresDelta {
   }
 }
 
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields, default, rename_all = "kebab-case")]
+pub struct VmDelta {
+  #[serde(skip_serializing_if = "is_default")]
+  pub dirty_bytes:                 Option<Expression>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub dirty_ratio:                 Option<Expression>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub dirty_background_bytes:      Option<Expression>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub dirty_background_ratio:      Option<Expression>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub transparent_hugepages:       Option<Expression>,
+  #[serde(skip_serializing_if = "is_default")]
+  pub transparent_hugepage_defrag: Option<Expression>,
+}
+
+impl VmDelta {
+  pub fn eval(&self, state: &EvalState<'_, '_>) -> anyhow::Result<vm::Delta> {
+    let delta = vm::Delta {
+      dirty_bytes:                 eval_u64(
+        &self.dirty_bytes,
+        state,
+        "vm.dirty-bytes",
+      )?,
+      dirty_ratio:                 eval_percent(
+        &self.dirty_ratio,
+        state,
+        "vm.dirty-ratio",
+      )?,
+      dirty_background_bytes:      eval_u64(
+        &self.dirty_background_bytes,
+        state,
+        "vm.dirty-background-bytes",
+      )?,
+      dirty_background_ratio:      eval_percent(
+        &self.dirty_background_ratio,
+        state,
+        "vm.dirty-background-ratio",
+      )?,
+      transparent_hugepages:       eval_string(
+        &self.transparent_hugepages,
+        state,
+        "vm.transparent-hugepages",
+      )?,
+      transparent_hugepage_defrag: eval_string(
+        &self.transparent_hugepage_defrag,
+        state,
+        "vm.transparent-hugepage-defrag",
+      )?,
+    };
+
+    delta.validate()?;
+    Ok(delta)
+  }
+}
+
 fn eval_u32(
   expression: &Option<Expression>,
   state: &EvalState<'_, '_>,
@@ -471,6 +529,24 @@ fn eval_u64(
   }
 
   Ok(Some(value as u64))
+}
+
+fn eval_string(
+  expression: &Option<Expression>,
+  state: &EvalState<'_, '_>,
+  name: &str,
+) -> anyhow::Result<Option<String>> {
+  let Some(expression) = expression else {
+    return Ok(None);
+  };
+  let Some(value) = expression.eval(state)? else {
+    return Ok(None);
+  };
+
+  value
+    .try_into_string()
+    .with_context(|| format!("`{name}` was not a string"))
+    .map(Some)
 }
 
 fn eval_percent(
@@ -1457,6 +1533,8 @@ pub struct Rule {
   #[serde(default, skip_serializing_if = "is_default")]
   pub uncore: UncoresDelta,
   #[serde(default, skip_serializing_if = "is_default")]
+  pub vm:     VmDelta,
+  #[serde(default, skip_serializing_if = "is_default")]
   pub power:  PowersDelta,
 }
 
@@ -1468,6 +1546,7 @@ impl Default for Rule {
       condition: literal_true(),
       cpu:       CpusDelta::default(),
       uncore:    UncoresDelta::default(),
+      vm:        VmDelta::default(),
       power:     PowersDelta::default(),
     }
   }

--- a/watt/cpu.rs
+++ b/watt/cpu.rs
@@ -2,7 +2,9 @@ use std::{
   cell::OnceCell,
   collections::HashMap,
   fmt,
+  fs::OpenOptions,
   hash,
+  io::Write,
   mem,
   string::ToString,
   sync::Arc,
@@ -679,6 +681,57 @@ impl Cpu {
     Ok(())
   }
 
+  pub fn set_pm_qos_resume_latency_us(
+    &self,
+    latency: &str,
+  ) -> anyhow::Result<()> {
+    let Self { number, .. } = *self;
+
+    fs::write(
+      format!(
+        "/sys/devices/system/cpu/cpu{number}/power/pm_qos_resume_latency_us"
+      ),
+      latency,
+    )
+    .with_context(|| {
+      format!(
+        "this probably means that {self} doesn't exist or doesn't support \
+         changing PM QoS resume latency"
+      )
+    })?;
+
+    log::info!(
+      "CPU {number} PM QoS resume latency set to {latency} us",
+      number = self.number,
+    );
+
+    Ok(())
+  }
+
+  pub fn set_pstate_min_performance_percent(percent: u8) -> anyhow::Result<()> {
+    fs::write(
+      "/sys/devices/system/cpu/intel_pstate/min_perf_pct",
+      &percent.to_string(),
+    )
+    .context("failed to set Intel P-State minimum performance percent")?;
+
+    log::info!("Intel P-State minimum performance set to {percent}%");
+
+    Ok(())
+  }
+
+  pub fn set_pstate_max_performance_percent(percent: u8) -> anyhow::Result<()> {
+    fs::write(
+      "/sys/devices/system/cpu/intel_pstate/max_perf_pct",
+      &percent.to_string(),
+    )
+    .context("failed to set Intel P-State maximum performance percent")?;
+
+    log::info!("Intel P-State maximum performance set to {percent}%");
+
+    Ok(())
+  }
+
   pub fn set_turbo<'a>(
     on: bool,
     mut cpus: impl Iterator<Item = &'a Self>,
@@ -782,6 +835,7 @@ pub struct Delta {
   pub energy_perf_bias:              Option<String>,
   pub frequency_mhz_minimum:         Option<u64>,
   pub frequency_mhz_maximum:         Option<u64>,
+  pub pm_qos_resume_latency_us:      Option<String>,
 }
 
 impl Delta {
@@ -791,6 +845,7 @@ impl Delta {
       && self.energy_perf_bias.is_some()
       && self.frequency_mhz_minimum.is_some()
       && self.frequency_mhz_maximum.is_some()
+      && self.pm_qos_resume_latency_us.is_some()
   }
 
   pub fn or(self, that: &Self) -> Self {
@@ -810,6 +865,9 @@ impl Delta {
       frequency_mhz_maximum:         self
         .frequency_mhz_maximum
         .or(that.frequency_mhz_maximum),
+      pm_qos_resume_latency_us:      self
+        .pm_qos_resume_latency_us
+        .or_else(|| that.pm_qos_resume_latency_us.clone()),
     }
   }
 
@@ -832,6 +890,100 @@ impl Delta {
 
     if let Some(mhz_maximum) = self.frequency_mhz_maximum {
       cpu.set_frequency_mhz_maximum(mhz_maximum)?;
+    }
+
+    if let Some(latency) = &self.pm_qos_resume_latency_us {
+      cpu.set_pm_qos_resume_latency_us(latency)?;
+    }
+
+    Ok(())
+  }
+}
+
+#[derive(Default, Debug, Clone, PartialEq)]
+#[must_use]
+pub struct GlobalDelta {
+  pub turbo:                          Option<bool>,
+  pub pstate_min_performance_percent: Option<u8>,
+  pub pstate_max_performance_percent: Option<u8>,
+  pub dma_latency_us:                 Option<i32>,
+}
+
+impl GlobalDelta {
+  pub fn is_some(&self) -> bool {
+    self.turbo.is_some()
+      && self.pstate_min_performance_percent.is_some()
+      && self.pstate_max_performance_percent.is_some()
+      && self.dma_latency_us.is_some()
+  }
+
+  pub fn or(self, that: &Self) -> Self {
+    Self {
+      turbo:                          self.turbo.or(that.turbo),
+      pstate_min_performance_percent: self
+        .pstate_min_performance_percent
+        .or(that.pstate_min_performance_percent),
+      pstate_max_performance_percent: self
+        .pstate_max_performance_percent
+        .or(that.pstate_max_performance_percent),
+      dma_latency_us:                 self
+        .dma_latency_us
+        .or(that.dma_latency_us),
+    }
+  }
+
+  pub fn apply<'a>(
+    &self,
+    cpus: impl Iterator<Item = &'a Cpu>,
+    dma_latency: &mut DmaLatency,
+  ) -> anyhow::Result<()> {
+    if let Some(percent) = self.pstate_min_performance_percent {
+      Cpu::set_pstate_min_performance_percent(percent)?;
+    }
+
+    if let Some(percent) = self.pstate_max_performance_percent {
+      Cpu::set_pstate_max_performance_percent(percent)?;
+    }
+
+    if let Some(turbo) = self.turbo {
+      Cpu::set_turbo(turbo, cpus)?;
+    }
+
+    dma_latency.apply(self.dma_latency_us)?;
+
+    Ok(())
+  }
+}
+
+#[derive(Default, Debug)]
+pub struct DmaLatency {
+  current: Option<i32>,
+  file:    Option<std::fs::File>,
+}
+
+impl DmaLatency {
+  pub fn apply(&mut self, latency_us: Option<i32>) -> anyhow::Result<()> {
+    if self.current == latency_us {
+      return Ok(());
+    }
+
+    if let Some(latency_us) = latency_us {
+      let mut file = OpenOptions::new()
+        .write(true)
+        .open("/dev/cpu_dma_latency")
+        .context("failed to open /dev/cpu_dma_latency")?;
+
+      file
+        .write_all(&latency_us.to_ne_bytes())
+        .context("failed to write CPU DMA latency request")?;
+
+      self.file = Some(file);
+      self.current = Some(latency_us);
+      log::info!("CPU DMA latency request set to {latency_us} us");
+    } else {
+      self.file = None;
+      self.current = None;
+      log::info!("CPU DMA latency request released");
     }
 
     Ok(())

--- a/watt/disk.rs
+++ b/watt/disk.rs
@@ -1,0 +1,221 @@
+use std::{
+  fmt,
+  hash,
+  path::PathBuf,
+  process::Command,
+};
+
+use anyhow::{
+  Context,
+  bail,
+};
+use yansi::Paint as _;
+
+use crate::fs;
+
+const BLOCK_PATH: &str = "/sys/block";
+
+#[derive(Debug, Clone)]
+pub struct Disk {
+  pub name: String,
+  pub path: PathBuf,
+}
+
+impl PartialEq for Disk {
+  fn eq(&self, other: &Self) -> bool {
+    self.name == other.name
+  }
+}
+
+impl Eq for Disk {}
+
+impl hash::Hash for Disk {
+  fn hash<H: hash::Hasher>(&self, state: &mut H) {
+    self.name.hash(state);
+  }
+}
+
+impl fmt::Display for Disk {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "disk '{name}'", name = self.name.cyan())
+  }
+}
+
+impl Disk {
+  pub fn all() -> anyhow::Result<Vec<Self>> {
+    let Some(entries) = fs::read_dir(BLOCK_PATH)? else {
+      return Ok(Vec::new());
+    };
+
+    let mut disks = Vec::new();
+
+    for entry in entries {
+      let entry = entry.context("failed to read block device entry")?;
+      let path = entry.path();
+      let name = entry.file_name().to_string_lossy().to_string();
+
+      if !path.join("queue").exists() || name.starts_with("loop") {
+        continue;
+      }
+      if fs::read_n::<u64>(path.join("removable"))?.unwrap_or(0) == 1 {
+        continue;
+      }
+
+      disks.push(Self { name, path });
+    }
+
+    Ok(disks)
+  }
+
+  pub fn set_scheduler(&self, value: &str) -> anyhow::Result<()> {
+    fs::write(self.path.join("queue/scheduler"), value)
+      .with_context(|| format!("failed to set scheduler for {self}"))
+  }
+
+  pub fn set_readahead_kib(&self, value: u64) -> anyhow::Result<()> {
+    fs::write(self.path.join("queue/read_ahead_kb"), &value.to_string())
+      .with_context(|| format!("failed to set readahead for {self}"))
+  }
+
+  pub fn set_apm(&self, value: u8) -> anyhow::Result<()> {
+    run_hdparm(self, format!("-B{value}"))
+  }
+
+  pub fn set_spindown(&self, value: u8) -> anyhow::Result<()> {
+    run_hdparm(self, format!("-S{value}"))
+  }
+}
+
+fn run_hdparm(disk: &Disk, option: String) -> anyhow::Result<()> {
+  let device = format!("/dev/{name}", name = disk.name);
+  let status = Command::new("hdparm")
+    .arg(option)
+    .arg(&device)
+    .status()
+    .with_context(|| format!("failed to execute hdparm for {disk}"))?;
+
+  if !status.success() {
+    bail!("hdparm failed for {disk} with status {status}");
+  }
+
+  Ok(())
+}
+
+pub fn set_alpm(policy: &str) -> anyhow::Result<()> {
+  let Some(entries) = fs::read_dir("/sys/class/scsi_host")? else {
+    return Ok(());
+  };
+
+  for entry in entries {
+    let entry = entry.context("failed to read SCSI host entry")?;
+    let host_path = entry.path();
+    let policy_path = host_path.join("link_power_management_policy");
+
+    if is_external_sata_port(&host_path)? {
+      log::info!(
+        "skipping ALPM for external or hotplug-capable SATA host '{host}'",
+        host = host_path.display(),
+      );
+      continue;
+    }
+
+    if policy_path.exists() {
+      fs::write(&policy_path, policy).with_context(|| {
+        format!(
+          "failed to set ALPM policy at '{path}'",
+          path = policy_path.display()
+        )
+      })?;
+    }
+  }
+
+  Ok(())
+}
+
+fn is_external_sata_port(host_path: &std::path::Path) -> anyhow::Result<bool> {
+  let Some(value) = fs::read(host_path.join("ahci_port_cmd"))? else {
+    return Ok(false);
+  };
+  let value = value.trim_start_matches("0x");
+  let port_cmd = u64::from_str_radix(value, 16).with_context(|| {
+    format!(
+      "failed to parse AHCI port command for '{host}'",
+      host = host_path.display()
+    )
+  })?;
+
+  const HOTPLUG_CAPABLE_PORT: u64 = 1 << 18;
+  const EXTERNAL_SATA_PORT: u64 = 1 << 21;
+
+  Ok(port_cmd & (HOTPLUG_CAPABLE_PORT | EXTERNAL_SATA_PORT) != 0)
+}
+
+#[derive(Default, Debug, Clone, PartialEq)]
+#[must_use]
+pub struct Delta {
+  pub scheduler:     Option<String>,
+  pub readahead_kib: Option<u64>,
+  pub apm:           Option<u8>,
+  pub spindown:      Option<u8>,
+}
+
+impl Delta {
+  pub fn is_some(&self) -> bool {
+    self.scheduler.is_some()
+      && self.readahead_kib.is_some()
+      && self.apm.is_some()
+      && self.spindown.is_some()
+  }
+
+  pub fn or(self, that: &Self) -> Self {
+    Self {
+      scheduler:     self.scheduler.or_else(|| that.scheduler.clone()),
+      readahead_kib: self.readahead_kib.or(that.readahead_kib),
+      apm:           self.apm.or(that.apm),
+      spindown:      self.spindown.or(that.spindown),
+    }
+  }
+
+  pub fn apply(&self, disk: &Disk) -> anyhow::Result<()> {
+    if let Some(value) = &self.scheduler {
+      disk.set_scheduler(value)?;
+    }
+    if let Some(value) = self.readahead_kib {
+      disk.set_readahead_kib(value)?;
+    }
+    if let Some(value) = self.apm {
+      disk.set_apm(value)?;
+    }
+    if let Some(value) = self.spindown {
+      disk.set_spindown(value)?;
+    }
+
+    Ok(())
+  }
+}
+
+#[derive(Default, Debug, Clone, PartialEq)]
+#[must_use]
+pub struct GlobalDelta {
+  pub alpm: Option<String>,
+}
+
+impl GlobalDelta {
+  pub fn is_some(&self) -> bool {
+    self.alpm.is_some()
+  }
+
+  pub fn or(self, that: &Self) -> Self {
+    Self {
+      alpm: self.alpm.or_else(|| that.alpm.clone()),
+    }
+  }
+
+  pub fn apply(&self) -> anyhow::Result<()> {
+    if let Some(value) = &self.alpm {
+      set_alpm(value)?;
+    }
+
+    Ok(())
+  }
+}

--- a/watt/gpu.rs
+++ b/watt/gpu.rs
@@ -1,0 +1,157 @@
+use std::{
+  fmt,
+  hash,
+  path::PathBuf,
+};
+
+use anyhow::{
+  Context,
+  bail,
+};
+use yansi::Paint as _;
+
+use crate::fs;
+
+#[derive(Debug, Clone)]
+pub struct Gpu {
+  pub name: String,
+  pub path: PathBuf,
+}
+
+impl PartialEq for Gpu {
+  fn eq(&self, other: &Self) -> bool {
+    self.name == other.name
+  }
+}
+
+impl Eq for Gpu {}
+
+impl hash::Hash for Gpu {
+  fn hash<H: hash::Hasher>(&self, state: &mut H) {
+    self.name.hash(state);
+  }
+}
+
+impl fmt::Display for Gpu {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "GPU '{name}'", name = self.name.cyan())
+  }
+}
+
+impl Gpu {
+  pub fn all() -> anyhow::Result<Vec<Self>> {
+    let Some(entries) = fs::read_dir("/sys/class/drm")? else {
+      return Ok(Vec::new());
+    };
+
+    let mut gpus = Vec::new();
+
+    for entry in entries {
+      let entry = entry.context("failed to read DRM device entry")?;
+      let name = entry.file_name().to_string_lossy().to_string();
+      if !name.starts_with("card") {
+        continue;
+      }
+
+      let path = entry.path();
+      if Self::panel_power_savings_path(&path).exists()
+        || Self::radeon_power_method_path(&path).exists()
+      {
+        gpus.push(Self { name, path });
+      }
+    }
+
+    Ok(gpus)
+  }
+
+  fn panel_power_savings_path(path: &std::path::Path) -> PathBuf {
+    path.join("amdgpu/panel_power_savings")
+  }
+
+  fn radeon_power_method_path(path: &std::path::Path) -> PathBuf {
+    path.join("device/power_method")
+  }
+
+  pub fn set_panel_power_savings(&self, value: u8) -> anyhow::Result<()> {
+    if value > 4 {
+      bail!("GPU panel power savings must be between 0 and 4, got {value}");
+    }
+
+    let path = Self::panel_power_savings_path(&self.path);
+    if !path.exists() {
+      log::debug!("{self} does not support AMDGPU panel power savings");
+      return Ok(());
+    }
+
+    fs::write(path, &value.to_string())
+      .with_context(|| format!("failed to set panel power savings for {self}"))
+  }
+
+  pub fn set_radeon_powersave(&self, value: &str) -> anyhow::Result<()> {
+    let method = Self::radeon_power_method_path(&self.path);
+    if !method.exists() {
+      log::debug!("{self} does not support Radeon power profiles");
+      return Ok(());
+    }
+
+    match value {
+      "default" | "auto" | "low" | "mid" | "high" => {
+        fs::write(&method, "profile")
+          .with_context(|| format!("failed to set power method for {self}"))?;
+        fs::write(self.path.join("device/power_profile"), value)
+          .with_context(|| format!("failed to set power profile for {self}"))?;
+      },
+      "dynpm" => {
+        fs::write(&method, "dynpm")
+          .with_context(|| format!("failed to set power method for {self}"))?
+      },
+      "dpm-battery" | "dpm-balanced" | "dpm-performance" => {
+        fs::write(&method, "dpm")
+          .with_context(|| format!("failed to set power method for {self}"))?;
+        fs::write(
+          self.path.join("device/power_dpm_state"),
+          value.trim_start_matches("dpm-"),
+        )
+        .with_context(|| format!("failed to set DPM state for {self}"))?;
+      },
+      _ => bail!("invalid Radeon powersave value: {value}"),
+    }
+
+    Ok(())
+  }
+}
+
+#[derive(Default, Debug, Clone, PartialEq)]
+#[must_use]
+pub struct Delta {
+  pub panel_power_savings: Option<u8>,
+  pub radeon_powersave:    Option<String>,
+}
+
+impl Delta {
+  pub fn is_some(&self) -> bool {
+    self.panel_power_savings.is_some() && self.radeon_powersave.is_some()
+  }
+
+  pub fn or(self, that: &Self) -> Self {
+    Self {
+      panel_power_savings: self
+        .panel_power_savings
+        .or(that.panel_power_savings),
+      radeon_powersave:    self
+        .radeon_powersave
+        .or_else(|| that.radeon_powersave.clone()),
+    }
+  }
+
+  pub fn apply(&self, gpu: &Gpu) -> anyhow::Result<()> {
+    if let Some(value) = self.panel_power_savings {
+      gpu.set_panel_power_savings(value)?;
+    }
+    if let Some(value) = &self.radeon_powersave {
+      gpu.set_radeon_powersave(value)?;
+    }
+
+    Ok(())
+  }
+}

--- a/watt/lib.rs
+++ b/watt/lib.rs
@@ -4,10 +4,14 @@ use anyhow::Context as _;
 use clap::Parser as _;
 use tokio::runtime::Builder as RuntimeBuilder;
 
+pub mod audio;
 pub mod cpu;
+pub mod disk;
+pub mod gpu;
 pub mod power_supply;
 pub mod system;
 pub mod uncore;
+pub mod usb;
 pub mod vm;
 
 pub mod fs;

--- a/watt/lib.rs
+++ b/watt/lib.rs
@@ -8,6 +8,7 @@ pub mod cpu;
 pub mod power_supply;
 pub mod system;
 pub mod uncore;
+pub mod vm;
 
 pub mod fs;
 

--- a/watt/lib.rs
+++ b/watt/lib.rs
@@ -7,6 +7,7 @@ use tokio::runtime::Builder as RuntimeBuilder;
 pub mod cpu;
 pub mod power_supply;
 pub mod system;
+pub mod uncore;
 
 pub mod fs;
 

--- a/watt/system.rs
+++ b/watt/system.rs
@@ -29,6 +29,7 @@ use crate::{
   power_supply,
   profile,
   uncore,
+  vm,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1099,6 +1100,7 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
           .iter()
           .map(|uncore| (Arc::clone(uncore), uncore::Delta::default()))
           .collect();
+      let mut vm_delta = vm::Delta::default();
 
       let mut power_deltas: HashMap<
         Arc<power_supply::PowerSupply>,
@@ -1151,12 +1153,14 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
 
           let power_some = {
             let uncore_deltas_lo = rule.uncore.eval(&eval_state)?;
+            let vm_delta_lo = rule.vm.eval(&eval_state)?;
 
             for (uncore, delta) in uncore_deltas.iter_mut() {
               if let Some(delta_lo) = uncore_deltas_lo.get(uncore) {
                 *delta = mem::take(delta).or(delta_lo);
               }
             }
+            vm_delta = mem::take(&mut vm_delta).or(&vm_delta_lo);
 
             let (power_deltas_lo, power_platform_profile_lo) =
               rule.power.eval(&eval_state)?;
@@ -1174,7 +1178,10 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
               power_deltas.values().all(|delta| delta.is_some());
             let uncore_some =
               uncore_deltas.values().all(|delta| delta.is_some());
-            deltas_some && power_platform_profile.is_some() && uncore_some
+            deltas_some
+              && power_platform_profile.is_some()
+              && uncore_some
+              && vm_delta.is_some()
           };
 
           if cpu_some && power_some {
@@ -1208,6 +1215,8 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
           .apply(&uncore)
           .with_context(|| format!("failed to apply delta to {uncore}"))?;
       }
+
+      vm_delta.apply().context("failed to apply VM delta")?;
 
       log::info!(
         "applying power supply deltas to {len} devices",

--- a/watt/system.rs
+++ b/watt/system.rs
@@ -23,12 +23,16 @@ use tokio::{
 };
 
 use crate::{
+  audio,
   config,
   cpu,
+  disk,
   fs,
+  gpu,
   power_supply,
   profile,
   uncore,
+  usb,
   vm,
 };
 
@@ -79,6 +83,15 @@ struct System {
 
   /// All Intel uncore frequency devices.
   uncores: HashSet<Arc<uncore::Uncore>>,
+
+  /// All block devices Watt can tune.
+  disks: HashSet<Arc<disk::Disk>>,
+
+  /// All USB devices Watt can tune.
+  usb_devices: HashSet<Arc<usb::UsbDevice>>,
+
+  /// All GPU devices Watt can tune.
+  gpus: HashSet<Arc<gpu::Gpu>>,
 
   /// All power supplies.
   power_supplies:   HashSet<Arc<power_supply::PowerSupply>>,
@@ -142,6 +155,45 @@ impl System {
         .collect();
       log::info!(
         "scanned all uncore devices in {millis}ms",
+        millis = start.elapsed().as_millis(),
+      );
+    }
+
+    {
+      let start = Instant::now();
+      self.disks = disk::Disk::all()
+        .context("failed to scan disks")?
+        .into_iter()
+        .map(Arc::from)
+        .collect();
+      log::info!(
+        "scanned all disks in {millis}ms",
+        millis = start.elapsed().as_millis(),
+      );
+    }
+
+    {
+      let start = Instant::now();
+      self.usb_devices = usb::UsbDevice::all()
+        .context("failed to scan USB devices")?
+        .into_iter()
+        .map(Arc::from)
+        .collect();
+      log::info!(
+        "scanned all USB devices in {millis}ms",
+        millis = start.elapsed().as_millis(),
+      );
+    }
+
+    {
+      let start = Instant::now();
+      self.gpus = gpu::Gpu::all()
+        .context("failed to scan GPUs")?
+        .into_iter()
+        .map(Arc::from)
+        .collect();
+      log::info!(
+        "scanned all GPUs in {millis}ms",
         millis = start.elapsed().as_millis(),
       );
     }
@@ -1083,6 +1135,9 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
 
         cpus: &system.cpus,
         uncores: &system.uncores,
+        disks: &system.disks,
+        usb_devices: &system.usb_devices,
+        gpus: &system.gpus,
         power_supplies: &system.power_supplies,
         cpu_log: &system.cpu_log,
       };
@@ -1101,6 +1156,23 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
           .map(|uncore| (Arc::clone(uncore), uncore::Delta::default()))
           .collect();
       let mut vm_delta = vm::Delta::default();
+      let mut disk_deltas: HashMap<Arc<disk::Disk>, disk::Delta> = system
+        .disks
+        .iter()
+        .map(|disk| (Arc::clone(disk), disk::Delta::default()))
+        .collect();
+      let mut disk_global_delta = disk::GlobalDelta::default();
+      let mut usb_deltas: HashMap<Arc<usb::UsbDevice>, usb::Delta> = system
+        .usb_devices
+        .iter()
+        .map(|device| (Arc::clone(device), usb::Delta::default()))
+        .collect();
+      let mut audio_delta = audio::Delta::default();
+      let mut gpu_deltas: HashMap<Arc<gpu::Gpu>, gpu::Delta> = system
+        .gpus
+        .iter()
+        .map(|gpu| (Arc::clone(gpu), gpu::Delta::default()))
+        .collect();
 
       let mut power_deltas: HashMap<
         Arc<power_supply::PowerSupply>,
@@ -1154,6 +1226,11 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
           let power_some = {
             let uncore_deltas_lo = rule.uncore.eval(&eval_state)?;
             let vm_delta_lo = rule.vm.eval(&eval_state)?;
+            let (disk_deltas_lo, disk_global_delta_lo) =
+              rule.disk.eval(&eval_state)?;
+            let usb_deltas_lo = rule.usb.eval(&eval_state)?;
+            let audio_delta_lo = rule.audio.eval(&eval_state)?;
+            let gpu_deltas_lo = rule.gpu.eval(&eval_state)?;
 
             for (uncore, delta) in uncore_deltas.iter_mut() {
               if let Some(delta_lo) = uncore_deltas_lo.get(uncore) {
@@ -1161,6 +1238,28 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
               }
             }
             vm_delta = mem::take(&mut vm_delta).or(&vm_delta_lo);
+
+            for (disk, delta) in disk_deltas.iter_mut() {
+              if let Some(delta_lo) = disk_deltas_lo.get(disk) {
+                *delta = mem::take(delta).or(delta_lo);
+              }
+            }
+            disk_global_delta =
+              mem::take(&mut disk_global_delta).or(&disk_global_delta_lo);
+
+            for (device, delta) in usb_deltas.iter_mut() {
+              if let Some(delta_lo) = usb_deltas_lo.get(device) {
+                *delta = mem::take(delta).or(delta_lo);
+              }
+            }
+
+            audio_delta = mem::take(&mut audio_delta).or(&audio_delta_lo);
+
+            for (gpu, delta) in gpu_deltas.iter_mut() {
+              if let Some(delta_lo) = gpu_deltas_lo.get(gpu) {
+                *delta = mem::take(delta).or(delta_lo);
+              }
+            }
 
             let (power_deltas_lo, power_platform_profile_lo) =
               rule.power.eval(&eval_state)?;
@@ -1178,10 +1277,18 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
               power_deltas.values().all(|delta| delta.is_some());
             let uncore_some =
               uncore_deltas.values().all(|delta| delta.is_some());
+            let disk_some = disk_deltas.values().all(|delta| delta.is_some())
+              && disk_global_delta.is_some();
+            let usb_some = usb_deltas.values().all(|delta| delta.is_some());
+            let gpu_some = gpu_deltas.values().all(|delta| delta.is_some());
             deltas_some
               && power_platform_profile.is_some()
               && uncore_some
               && vm_delta.is_some()
+              && disk_some
+              && usb_some
+              && audio_delta.is_some()
+              && gpu_some
           };
 
           if cpu_some && power_some {
@@ -1217,6 +1324,41 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
       }
 
       vm_delta.apply().context("failed to apply VM delta")?;
+
+      log::info!(
+        "applying disk deltas to {len} devices",
+        len = disk_deltas.len(),
+      );
+      for (disk, delta) in disk_deltas {
+        delta
+          .apply(&disk)
+          .with_context(|| format!("failed to apply delta to {disk}"))?;
+      }
+      disk_global_delta
+        .apply()
+        .context("failed to apply global disk delta")?;
+
+      log::info!(
+        "applying USB deltas to {len} devices",
+        len = usb_deltas.len(),
+      );
+      for (device, delta) in usb_deltas {
+        delta
+          .apply(&device)
+          .with_context(|| format!("failed to apply delta to {device}"))?;
+      }
+
+      audio_delta.apply().context("failed to apply audio delta")?;
+
+      log::info!(
+        "applying GPU deltas to {len} devices",
+        len = gpu_deltas.len(),
+      );
+      for (gpu, delta) in gpu_deltas {
+        delta
+          .apply(&gpu)
+          .with_context(|| format!("failed to apply delta to {gpu}"))?;
+      }
 
       log::info!(
         "applying power supply deltas to {len} devices",

--- a/watt/system.rs
+++ b/watt/system.rs
@@ -994,6 +994,7 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
   let mut last_polling_delay = None::<Duration>;
   let mut last_user_activity = Instant::now();
   let mut system = System::default();
+  let mut dma_latency = cpu::DmaLatency::default();
   let shutdown_signal = signal::ctrl_c();
   tokio::pin!(shutdown_signal);
   let mut sleep_for = Duration::ZERO;
@@ -1072,7 +1073,7 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
         .iter()
         .map(|cpu| (Arc::clone(cpu), cpu::Delta::default()))
         .collect();
-      let mut cpu_turbo: Option<bool> = None;
+      let mut cpu_global_delta = cpu::GlobalDelta::default();
 
       let mut power_deltas: HashMap<
         Arc<power_supply::PowerSupply>,
@@ -1107,7 +1108,8 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
           last_applied_rules.push(rule.name.clone());
 
           let cpu_some = {
-            let (cpu_deltas_lo, cpu_turbo_lo) = rule.cpu.eval(&eval_state)?;
+            let (cpu_deltas_lo, cpu_global_delta_lo) =
+              rule.cpu.eval(&eval_state)?;
 
             for (cpu, delta) in cpu_deltas.iter_mut() {
               let delta_lo = cpu_deltas_lo
@@ -1117,10 +1119,11 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
               *delta = mem::take(delta).or(delta_lo);
             }
 
-            cpu_turbo = cpu_turbo.or(cpu_turbo_lo);
+            cpu_global_delta =
+              mem::take(&mut cpu_global_delta).or(&cpu_global_delta_lo);
 
             let deltas_some = cpu_deltas.values().all(|delta| delta.is_some());
-            deltas_some && cpu_turbo.is_some()
+            deltas_some && cpu_global_delta.is_some()
           };
 
           let power_some = {
@@ -1160,10 +1163,9 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
 
       log::info!("applying CPU deltas to {len} CPUs", len = cpu_deltas.len());
 
-      if let Some(turbo) = cpu_turbo {
-        cpu::Cpu::set_turbo(turbo, cpu_deltas.keys().map(|arc| &**arc))
-          .context("failed to set CPU turbo")?;
-      }
+      cpu_global_delta
+        .apply(cpu_deltas.keys().map(|arc| &**arc), &mut dma_latency)
+        .context("failed to apply global CPU delta")?;
 
       log::info!(
         "applying power supply deltas to {len} devices",

--- a/watt/system.rs
+++ b/watt/system.rs
@@ -28,6 +28,7 @@ use crate::{
   fs,
   power_supply,
   profile,
+  uncore,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -74,6 +75,9 @@ struct System {
   /// CPU usage and temperature log.
   cpu_log:          VecDeque<CpuLog>,
   cpu_temperatures: HashMap<u32, f64>,
+
+  /// All Intel uncore frequency devices.
+  uncores: HashSet<Arc<uncore::Uncore>>,
 
   /// All power supplies.
   power_supplies:   HashSet<Arc<power_supply::PowerSupply>>,
@@ -124,6 +128,19 @@ impl System {
         .collect();
       log::info!(
         "scanned all power supplies in {millis}ms",
+        millis = start.elapsed().as_millis(),
+      );
+    }
+
+    {
+      let start = Instant::now();
+      self.uncores = uncore::Uncore::all()
+        .context("failed to scan uncore devices")?
+        .into_iter()
+        .map(Arc::from)
+        .collect();
+      log::info!(
+        "scanned all uncore devices in {millis}ms",
         millis = start.elapsed().as_millis(),
       );
     }
@@ -1064,6 +1081,7 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
         context: config::EvalContext::WidestPossible,
 
         cpus: &system.cpus,
+        uncores: &system.uncores,
         power_supplies: &system.power_supplies,
         cpu_log: &system.cpu_log,
       };
@@ -1074,6 +1092,13 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
         .map(|cpu| (Arc::clone(cpu), cpu::Delta::default()))
         .collect();
       let mut cpu_global_delta = cpu::GlobalDelta::default();
+
+      let mut uncore_deltas: HashMap<Arc<uncore::Uncore>, uncore::Delta> =
+        system
+          .uncores
+          .iter()
+          .map(|uncore| (Arc::clone(uncore), uncore::Delta::default()))
+          .collect();
 
       let mut power_deltas: HashMap<
         Arc<power_supply::PowerSupply>,
@@ -1112,11 +1137,9 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
               rule.cpu.eval(&eval_state)?;
 
             for (cpu, delta) in cpu_deltas.iter_mut() {
-              let delta_lo = cpu_deltas_lo
-                .get(cpu)
-                .expect("cpu deltas and cpus should match");
-
-              *delta = mem::take(delta).or(delta_lo);
+              if let Some(delta_lo) = cpu_deltas_lo.get(cpu) {
+                *delta = mem::take(delta).or(delta_lo);
+              }
             }
 
             cpu_global_delta =
@@ -1127,15 +1150,21 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
           };
 
           let power_some = {
+            let uncore_deltas_lo = rule.uncore.eval(&eval_state)?;
+
+            for (uncore, delta) in uncore_deltas.iter_mut() {
+              if let Some(delta_lo) = uncore_deltas_lo.get(uncore) {
+                *delta = mem::take(delta).or(delta_lo);
+              }
+            }
+
             let (power_deltas_lo, power_platform_profile_lo) =
               rule.power.eval(&eval_state)?;
 
             for (power, delta) in power_deltas.iter_mut() {
-              let delta_lo = power_deltas_lo
-                .get(power)
-                .expect("power deltas and power supplies should match");
-
-              *delta = mem::take(delta).or(delta_lo);
+              if let Some(delta_lo) = power_deltas_lo.get(power) {
+                *delta = mem::take(delta).or(delta_lo);
+              }
             }
 
             power_platform_profile =
@@ -1143,7 +1172,9 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
 
             let deltas_some =
               power_deltas.values().all(|delta| delta.is_some());
-            deltas_some && power_platform_profile.is_some()
+            let uncore_some =
+              uncore_deltas.values().all(|delta| delta.is_some());
+            deltas_some && power_platform_profile.is_some() && uncore_some
           };
 
           if cpu_some && power_some {
@@ -1166,6 +1197,17 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
       cpu_global_delta
         .apply(cpu_deltas.keys().map(|arc| &**arc), &mut dma_latency)
         .context("failed to apply global CPU delta")?;
+
+      log::info!(
+        "applying uncore deltas to {len} devices",
+        len = uncore_deltas.len(),
+      );
+
+      for (uncore, delta) in uncore_deltas {
+        delta
+          .apply(&uncore)
+          .with_context(|| format!("failed to apply delta to {uncore}"))?;
+      }
 
       log::info!(
         "applying power supply deltas to {len} devices",

--- a/watt/system.rs
+++ b/watt/system.rs
@@ -69,7 +69,9 @@ struct PowerSupplyLog {
 struct System {
   is_ac: bool,
 
-  lid_closed: bool,
+  lid_closed:      bool,
+  virtual_machine: bool,
+  chassis_type:    Option<String>,
 
   load_average_1min:  f64,
   load_average_5min:  f64,
@@ -241,6 +243,18 @@ impl System {
       self.scan_lid_state()?;
       log::info!(
         "scanned lid state in {millis}ms",
+        millis = start.elapsed().as_millis(),
+      );
+    }
+
+    {
+      let start = Instant::now();
+      self.chassis_type =
+        read_chassis_type().context("failed to read chassis type")?;
+      self.virtual_machine = detect_virtual_machine()
+        .context("failed to detect virtualization status")?;
+      log::info!(
+        "scanned platform identity in {millis}ms",
         millis = start.elapsed().as_millis(),
       );
     }
@@ -957,6 +971,63 @@ fn detect_performance_degradation(_system: &System) -> Option<String> {
   None
 }
 
+fn read_chassis_type() -> anyhow::Result<Option<String>> {
+  let Some(chassis_type) = fs::read("/sys/class/dmi/id/chassis_type")? else {
+    return Ok(None);
+  };
+
+  Ok(match chassis_type.trim() {
+    "3" | "4" | "5" | "6" | "7" | "15" | "16" | "17" => {
+      Some("desktop".to_owned())
+    },
+    "8" => Some("portable".to_owned()),
+    "9" | "10" | "14" | "31" => Some("laptop".to_owned()),
+    "11" => Some("handheld".to_owned()),
+    "13" => Some("all-in-one".to_owned()),
+    _ => None,
+  })
+}
+
+fn detect_virtual_machine() -> anyhow::Result<bool> {
+  const DMI_PATHS: &[&str] = &[
+    "/sys/class/dmi/id/product_name",
+    "/sys/class/dmi/id/sys_vendor",
+    "/sys/class/dmi/id/board_vendor",
+    "/sys/class/dmi/id/bios_vendor",
+  ];
+  const VIRTUAL_MARKERS: &[&str] = &[
+    "bhyve",
+    "bochs",
+    "hyper-v",
+    "kvm",
+    "parallels",
+    "qemu",
+    "virtualbox",
+    "vmware",
+    "xen",
+  ];
+
+  for path in DMI_PATHS {
+    let Some(value) = fs::read(path)? else {
+      continue;
+    };
+    let value = value.to_lowercase();
+    if VIRTUAL_MARKERS.iter().any(|marker| value.contains(marker)) {
+      return Ok(true);
+    }
+  }
+
+  if let Some(cpuinfo) = fs::read("/proc/cpuinfo")? {
+    return Ok(
+      cpuinfo
+        .lines()
+        .any(|line| line.starts_with("flags") && line.contains(" hypervisor")),
+    );
+  }
+
+  Ok(false)
+}
+
 #[derive(Debug)]
 pub struct DaemonState {
   system:               System,
@@ -1118,6 +1189,8 @@ pub async fn run_daemon(config: config::DaemonConfig) -> anyhow::Result<()> {
           .map(|u64| u64 as f64),
 
         lid_closed: system.lid_closed,
+        virtual_machine: system.virtual_machine,
+        chassis_type: system.chassis_type.as_deref(),
 
         power_supply_charge: system
           .power_supply_log

--- a/watt/uncore.rs
+++ b/watt/uncore.rs
@@ -1,0 +1,182 @@
+use std::{
+  fmt,
+  hash,
+  path::PathBuf,
+};
+
+use anyhow::{
+  Context,
+  bail,
+};
+use yansi::Paint as _;
+
+use crate::fs;
+
+const UNCORE_PATH: &str = "/sys/devices/system/cpu/intel_uncore_frequency";
+
+#[derive(Debug, Clone)]
+pub struct Uncore {
+  pub name:            String,
+  pub path:            PathBuf,
+  pub initial_min_khz: u64,
+  pub initial_max_khz: u64,
+  pub min_khz:         u64,
+  pub max_khz:         u64,
+}
+
+impl PartialEq for Uncore {
+  fn eq(&self, other: &Self) -> bool {
+    self.name == other.name
+  }
+}
+
+impl Eq for Uncore {}
+
+impl hash::Hash for Uncore {
+  fn hash<H: hash::Hasher>(&self, state: &mut H) {
+    self.name.hash(state);
+  }
+}
+
+impl fmt::Display for Uncore {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "uncore device '{name}'", name = self.name.cyan())
+  }
+}
+
+impl Uncore {
+  pub fn all() -> anyhow::Result<Vec<Self>> {
+    log::info!("detecting Intel uncore frequency devices...");
+
+    let Some(entries) = fs::read_dir(UNCORE_PATH)
+      .context("failed to read Intel uncore frequency devices")?
+    else {
+      log::debug!("Intel uncore frequency control is not available");
+      return Ok(Vec::new());
+    };
+
+    let mut uncores = Vec::new();
+
+    for entry in entries {
+      let entry = entry
+        .with_context(|| format!("failed to read entry of '{UNCORE_PATH}'"))?;
+      let path = entry.path();
+
+      if !path.is_dir() || !path.join("min_freq_khz").exists() {
+        continue;
+      }
+
+      let name = entry.file_name().to_string_lossy().to_string();
+      let uncore = Self::scan(name, path)?;
+      uncores.push(uncore);
+    }
+
+    log::info!("detected {len} uncore devices", len = uncores.len());
+    Ok(uncores)
+  }
+
+  fn scan(name: String, path: PathBuf) -> anyhow::Result<Self> {
+    let initial_min_khz = read_required(&path, "initial_min_freq_khz")?;
+    let initial_max_khz = read_required(&path, "initial_max_freq_khz")?;
+    let min_khz = read_required(&path, "min_freq_khz")?;
+    let max_khz = read_required(&path, "max_freq_khz")?;
+
+    Ok(Self {
+      name,
+      path,
+      initial_min_khz,
+      initial_max_khz,
+      min_khz,
+      max_khz,
+    })
+  }
+
+  pub fn set_min_khz(&self, value: u64) -> anyhow::Result<()> {
+    if value < self.initial_min_khz {
+      bail!(
+        "new uncore minimum frequency ({value} kHz) cannot be lower than the \
+         initial minimum frequency ({min} kHz) for {self}",
+        min = self.initial_min_khz,
+      );
+    }
+    fs::write(self.path.join("min_freq_khz"), &value.to_string())
+      .with_context(|| format!("failed to set minimum frequency for {self}"))?;
+
+    log::info!("{self} minimum frequency set to {value} kHz");
+    Ok(())
+  }
+
+  pub fn set_max_khz(&self, value: u64) -> anyhow::Result<()> {
+    if value > self.initial_max_khz {
+      bail!(
+        "new uncore maximum frequency ({value} kHz) cannot be higher than the \
+         initial maximum frequency ({max} kHz) for {self}",
+        max = self.initial_max_khz,
+      );
+    }
+    fs::write(self.path.join("max_freq_khz"), &value.to_string())
+      .with_context(|| format!("failed to set maximum frequency for {self}"))?;
+
+    log::info!("{self} maximum frequency set to {value} kHz");
+    Ok(())
+  }
+}
+
+fn read_required(path: &std::path::Path, file: &str) -> anyhow::Result<u64> {
+  fs::read_n::<u64>(path.join(file))?
+    .with_context(|| format!("missing uncore frequency file '{file}'"))
+}
+
+#[derive(Default, Debug, Clone, PartialEq)]
+#[must_use]
+pub struct Delta {
+  pub frequency_khz_minimum: Option<u64>,
+  pub frequency_khz_maximum: Option<u64>,
+}
+
+impl Delta {
+  pub fn is_some(&self) -> bool {
+    self.frequency_khz_minimum.is_some() && self.frequency_khz_maximum.is_some()
+  }
+
+  pub fn or(self, that: &Self) -> Self {
+    Self {
+      frequency_khz_minimum: self
+        .frequency_khz_minimum
+        .or(that.frequency_khz_minimum),
+      frequency_khz_maximum: self
+        .frequency_khz_maximum
+        .or(that.frequency_khz_maximum),
+    }
+  }
+
+  pub fn apply(&self, uncore: &Uncore) -> anyhow::Result<()> {
+    let target_min = self.frequency_khz_minimum.unwrap_or(uncore.min_khz);
+    let target_max = self.frequency_khz_maximum.unwrap_or(uncore.max_khz);
+
+    if target_min > target_max {
+      bail!(
+        "new uncore minimum frequency ({target_min} kHz) cannot be higher \
+         than the new maximum frequency ({target_max} kHz) for {uncore}"
+      );
+    }
+
+    if target_min > uncore.max_khz {
+      if let Some(value) = self.frequency_khz_maximum {
+        uncore.set_max_khz(value)?;
+      }
+      if let Some(value) = self.frequency_khz_minimum {
+        uncore.set_min_khz(value)?;
+      }
+    } else {
+      if let Some(value) = self.frequency_khz_minimum {
+        uncore.set_min_khz(value)?;
+      }
+      if let Some(value) = self.frequency_khz_maximum {
+        uncore.set_max_khz(value)?;
+      }
+    }
+
+    Ok(())
+  }
+}

--- a/watt/usb.rs
+++ b/watt/usb.rs
@@ -1,0 +1,108 @@
+use std::{
+  fmt,
+  hash,
+  path::PathBuf,
+};
+
+use anyhow::Context;
+use yansi::Paint as _;
+
+use crate::fs;
+
+#[derive(Debug, Clone)]
+pub struct UsbDevice {
+  pub name: String,
+  pub path: PathBuf,
+}
+
+impl PartialEq for UsbDevice {
+  fn eq(&self, other: &Self) -> bool {
+    self.name == other.name
+  }
+}
+
+impl Eq for UsbDevice {}
+
+impl hash::Hash for UsbDevice {
+  fn hash<H: hash::Hasher>(&self, state: &mut H) {
+    self.name.hash(state);
+  }
+}
+
+impl fmt::Display for UsbDevice {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "USB device '{name}'", name = self.name.cyan())
+  }
+}
+
+impl UsbDevice {
+  pub fn all() -> anyhow::Result<Vec<Self>> {
+    let Some(entries) = fs::read_dir("/sys/bus/usb/devices")? else {
+      return Ok(Vec::new());
+    };
+
+    let mut devices = Vec::new();
+
+    for entry in entries {
+      let entry = entry.context("failed to read USB device entry")?;
+      let path = entry.path();
+      if !path.join("power").exists() || !path.join("idVendor").exists() {
+        continue;
+      }
+
+      devices.push(Self {
+        name: entry.file_name().to_string_lossy().to_string(),
+        path,
+      });
+    }
+
+    Ok(devices)
+  }
+
+  pub fn set_autosuspend(&self, enabled: bool) -> anyhow::Result<()> {
+    let value = if enabled { "auto" } else { "on" };
+    fs::write(self.path.join("power/control"), value)
+      .with_context(|| format!("failed to set autosuspend for {self}"))
+  }
+
+  pub fn set_autosuspend_delay_ms(&self, delay_ms: u64) -> anyhow::Result<()> {
+    fs::write(
+      self.path.join("power/autosuspend_delay_ms"),
+      &delay_ms.to_string(),
+    )
+    .with_context(|| format!("failed to set autosuspend delay for {self}"))
+  }
+}
+
+#[derive(Default, Debug, Clone, PartialEq)]
+#[must_use]
+pub struct Delta {
+  pub autosuspend:          Option<bool>,
+  pub autosuspend_delay_ms: Option<u64>,
+}
+
+impl Delta {
+  pub fn is_some(&self) -> bool {
+    self.autosuspend.is_some() && self.autosuspend_delay_ms.is_some()
+  }
+
+  pub fn or(self, that: &Self) -> Self {
+    Self {
+      autosuspend:          self.autosuspend.or(that.autosuspend),
+      autosuspend_delay_ms: self
+        .autosuspend_delay_ms
+        .or(that.autosuspend_delay_ms),
+    }
+  }
+
+  pub fn apply(&self, device: &UsbDevice) -> anyhow::Result<()> {
+    if let Some(enabled) = self.autosuspend {
+      device.set_autosuspend(enabled)?;
+    }
+    if let Some(delay_ms) = self.autosuspend_delay_ms {
+      device.set_autosuspend_delay_ms(delay_ms)?;
+    }
+
+    Ok(())
+  }
+}

--- a/watt/vm.rs
+++ b/watt/vm.rs
@@ -1,0 +1,131 @@
+use std::path::Path;
+
+use anyhow::{
+  Context,
+  bail,
+};
+
+use crate::fs;
+
+#[derive(Default, Debug, Clone, PartialEq)]
+#[must_use]
+pub struct Delta {
+  pub dirty_bytes:                 Option<u64>,
+  pub dirty_ratio:                 Option<u8>,
+  pub dirty_background_bytes:      Option<u64>,
+  pub dirty_background_ratio:      Option<u8>,
+  pub transparent_hugepages:       Option<String>,
+  pub transparent_hugepage_defrag: Option<String>,
+}
+
+impl Delta {
+  pub fn is_some(&self) -> bool {
+    self.dirty_bytes.is_some()
+      && self.dirty_ratio.is_some()
+      && self.dirty_background_bytes.is_some()
+      && self.dirty_background_ratio.is_some()
+      && self.transparent_hugepages.is_some()
+      && self.transparent_hugepage_defrag.is_some()
+  }
+
+  pub fn or(self, that: &Self) -> Self {
+    Self {
+      dirty_bytes:                 self.dirty_bytes.or(that.dirty_bytes),
+      dirty_ratio:                 self.dirty_ratio.or(that.dirty_ratio),
+      dirty_background_bytes:      self
+        .dirty_background_bytes
+        .or(that.dirty_background_bytes),
+      dirty_background_ratio:      self
+        .dirty_background_ratio
+        .or(that.dirty_background_ratio),
+      transparent_hugepages:       self
+        .transparent_hugepages
+        .or_else(|| that.transparent_hugepages.clone()),
+      transparent_hugepage_defrag: self
+        .transparent_hugepage_defrag
+        .or_else(|| that.transparent_hugepage_defrag.clone()),
+    }
+  }
+
+  pub fn validate(&self) -> anyhow::Result<()> {
+    if self.dirty_bytes.is_some() && self.dirty_ratio.is_some() {
+      bail!("`vm.dirty-bytes` conflicts with `vm.dirty-ratio`");
+    }
+    if self.dirty_background_bytes.is_some()
+      && self.dirty_background_ratio.is_some()
+    {
+      bail!(
+        "`vm.dirty-background-bytes` conflicts with \
+         `vm.dirty-background-ratio`"
+      );
+    }
+
+    if let Some(value) = &self.transparent_hugepages
+      && !matches!(&**value, "always" | "madvise" | "never")
+    {
+      bail!("invalid `vm.transparent-hugepages`: {value}");
+    }
+
+    if let Some(value) = &self.transparent_hugepage_defrag
+      && !matches!(
+        &**value,
+        "always" | "defer" | "defer+madvise" | "madvise" | "never"
+      )
+    {
+      bail!("invalid `vm.transparent-hugepage-defrag`: {value}");
+    }
+
+    Ok(())
+  }
+
+  pub fn apply(&self) -> anyhow::Result<()> {
+    self.validate()?;
+
+    if let Some(value) = self.dirty_bytes {
+      write_proc_sys_vm("dirty_bytes", value)?;
+    }
+    if let Some(value) = self.dirty_ratio {
+      write_proc_sys_vm("dirty_ratio", value)?;
+    }
+    if let Some(value) = self.dirty_background_bytes {
+      write_proc_sys_vm("dirty_background_bytes", value)?;
+    }
+    if let Some(value) = self.dirty_background_ratio {
+      write_proc_sys_vm("dirty_background_ratio", value)?;
+    }
+
+    if let Some(value) = &self.transparent_hugepages {
+      write_transparent_hugepage("enabled", value)?;
+    }
+    if let Some(value) = &self.transparent_hugepage_defrag {
+      write_transparent_hugepage("defrag", value)?;
+    }
+
+    Ok(())
+  }
+}
+
+fn write_proc_sys_vm(
+  name: &str,
+  value: impl std::fmt::Display,
+) -> anyhow::Result<()> {
+  fs::write(format!("/proc/sys/vm/{name}"), &value.to_string())
+    .with_context(|| format!("failed to set vm sysctl '{name}'"))
+}
+
+fn write_transparent_hugepage(name: &str, value: &str) -> anyhow::Result<()> {
+  let base = transparent_hugepage_path()
+    .context("transparent hugepage control is not available")?;
+  fs::write(base.join(name), value)
+    .with_context(|| format!("failed to set transparent hugepage '{name}'"))
+}
+
+fn transparent_hugepage_path() -> Option<&'static Path> {
+  let path = Path::new("/sys/kernel/mm/transparent_hugepage");
+  if path.exists() {
+    return Some(path);
+  }
+
+  let path = Path::new("/sys/kernel/mm/redhat_transparent_hugepage");
+  path.exists().then_some(path)
+}


### PR DESCRIPTION
I've been looking into Tuned recently. Besides being profoundly insignificant, it appears to have some good ideas I think are worth providing in Watt. Some of the new additions are:

1. An `audio` module that allows audio power management parameters - this is actually not too significant (so insignificant, in fact, that I was not able to benchmark) but I expect different devices to have different experiences. 

2. A new `disk` module to enumerate block devices, set I/O scheduler, readahead, APM, and spindown (via sysfs of course) or `hdparm`, and configure SATA ALPM policy. Also lets us skip external/hotplug SATA ports. 

3. Support for setting per-CPU PM QoS resume latency (`pm_qos_resume_latency_us`) and Intel P-State performance percent minimum/maximum

In less relevant news, I've itroduced a `GlobalDelta` for CPU to group global CPU settings (turbo, P-State, DMA latency) and a `DmaLatency` struct to manage `/dev/cpu_dma_latency` requests. Haven't been able to test this too well though.

Since we're adding all those modules, I've decided that it's a good opportunity to try and split the documentation to be more readable. In the future I'll consider hosting a tiny website with NDG or similar.