### PR TITLE
watt: use `first-available-governor` for `cpu.governor` for Intel compat

### DIFF
--- a/watt/config.toml
+++ b/watt/config.toml
@@ -81,7 +81,7 @@ priority = 60
 
 cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "balance-performance", then = "balance-performance" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "balance_performance", then = "balance_performance" }
-cpu.governor                      = { if.is-governor-available = "schedutil", then = "schedutil" }
+cpu.governor                      = { first-available-governor = [ "schedutil", "powersave" ] }
 
 [[rule]]
 if.all = [
@@ -134,6 +134,6 @@ cpu.turbo                         = { if = "?turbo-available", then = false }
 [[rule]]
 cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "balance-performance", then = "balance-performance" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "balance_performance", then = "balance_performance" }
-cpu.governor                      = { if.is-governor-available = "schedutil", then = "schedutil" }
+cpu.governor                      = { first-available-governor = [ "schedutil", "powersave" ] }
 name                              = "default-balanced"
 priority                          = 0

--- a/watt/config.toml
+++ b/watt/config.toml
@@ -44,11 +44,11 @@ cpu.energy-perf-bias = { if.all = [
   { not.is-driver-loaded = "intel_pstate" },
   { is-energy-perf-bias-available = "performance" },
 ], then = "performance" }
-cpu.energy-performance-preference = { if.all = [
-  { not.is-driver-loaded = "intel_pstate" },
+cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "performance", then = "performance" }
+cpu.governor = { else = { if.is-governor-available = "performance", then = "performance" }, if.all = [
+  { is-driver-loaded = "intel_pstate" },
   { is-energy-performance-preference-available = "performance" },
-], then = "performance" }
-cpu.governor = { if.is-governor-available = "performance", then = "performance" }
+], then = "powersave" }
 cpu.turbo = { if = "?turbo-available", then = true }
 
 [[rule]]
@@ -64,11 +64,11 @@ cpu.energy-perf-bias = { if.all = [
   { not.is-driver-loaded = "intel_pstate" },
   { is-energy-perf-bias-available = "balance-performance" },
 ], then = "balance-performance" }
-cpu.energy-performance-preference = { if.all = [
-  { not.is-driver-loaded = "intel_pstate" },
+cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "performance", then = "performance" }
+cpu.governor = { else = { if.is-governor-available = "performance", then = "performance" }, if.all = [
+  { is-driver-loaded = "intel_pstate" },
   { is-energy-performance-preference-available = "performance" },
-], then = "performance" }
-cpu.governor = { if.is-governor-available = "performance", then = "performance" }
+], then = "powersave" }
 cpu.turbo = { if = "?turbo-available", then = true }
 
 [[rule]]


### PR DESCRIPTION
`intel_pstate` in active mode does not expose `schedutil`; its dynamic governor is `powersave`. Writing EPP requires a non-`performance` governor, so fall back to `powersave` to avoid leaving the governor at `performance`. Otherwise locks EPP and makes the write fail with `EBUSY`.


Change-Id: I23a554aa94fa28fe3a2dcd1dd8156e736a6a6964