### PR TITLE
nix: general cleanup & allow module consumption by non-flake users

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,39 +1,50 @@
 {
   inputs.nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
 
-  outputs = {
-    self,
-    nixpkgs,
-    ...
-  } @ inputs: let
-    forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux"];
-    pkgsForEach = forAllSystems (system: nixpkgs.legacyPackages.${system});
-  in {
-    overlays = {
-      watt = final: _: {
-        watt = final.callPackage ./nix/package.nix {};
+  outputs =
+    {
+      self,
+      nixpkgs,
+      ...
+    }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems =
+        set:
+        builtins.listToAttrs (
+          map (system: {
+            name = system;
+            value = set nixpkgs.legacyPackages.${system} system;
+          }) systems
+        );
+    in
+    {
+      overlays = {
+        watt = final: _: {
+          watt = final.callPackage ./nix/package.nix { };
+        };
+        default = self.overlays.watt;
       };
-      default = self.overlays.watt;
+
+      packages = forAllSystems (
+        pkgs: system: {
+          watt = pkgs.callPackage ./nix/package.nix { };
+          default = self.packages.${system}.watt;
+        }
+      );
+
+      devShells = forAllSystems (pkgs: system: {
+        default = pkgs.callPackage ./nix/shell.nix { };
+      });
+
+      nixosModules = {
+        watt = import ./nix/module.nix;
+        default = self.nixosModules.watt;
+      };
+
+      formatter = forAllSystems (pkgs: _: pkgs.alejandra);
     };
-
-    packages =
-      nixpkgs.lib.mapAttrs (system: pkgs: {
-        watt = pkgs.callPackage ./nix/package.nix {};
-        default = self.packages.${system}.watt;
-      })
-      pkgsForEach;
-
-    devShells =
-      nixpkgs.lib.mapAttrs (system: pkgs: {
-        default = pkgs.callPackage ./nix/shell.nix {};
-      })
-      pkgsForEach;
-
-    nixosModules = {
-      watt = import ./nix/module.nix inputs;
-      default = self.nixosModules.watt;
-    };
-
-    formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.alejandra);
-  };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,18 +1,20 @@
-inputs: {
+{
   config,
   pkgs,
   lib,
   ...
 }: let
+  inherit (lib) types;
   inherit (lib.modules) mkIf;
   inherit (lib.options) mkOption mkEnableOption mkPackageOption;
-  inherit (lib.types) submodule;
   inherit (lib.meta) getExe;
 
   cfg = config.services.watt;
 
   format = pkgs.formats.toml {};
   cfgFile = format.generate "watt-config.toml" cfg.settings;
+
+  wattPackage = pkgs.callPackage ./package.nix {};
 
   conflictingServices = [
     "power-profiles-daemon"
@@ -22,17 +24,49 @@ inputs: {
     "thermald"
     "tuned"
   ];
+
+  configString = lib.mkMerge [
+    (mkIf cfg.configFile != null cfg.configFile)
+    (mkIf (cfg.configFile == null) cfg.settings)
+  ];
+
+  wrapper = pkgs.stdenvNoCC.mkDerivation {
+    name = "watt-wrapped";
+    buildInputs = [pkgs.makeWrapper];
+    paths = [cfg.package];
+    meta.mainProgram = "watt";
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+    enableParallelBuilding = true;
+
+    buildPhase = ''
+      mkdir -p $out
+      wrapProgram $out/bin/watt --set WATT_CONFIG ${configString}
+    '';
+  };
 in {
   options.services.watt = {
     enable = mkEnableOption "Watt, automatic CPU speed & power optimizer for Linux";
-    package = mkPackageOption inputs.self.packages.${pkgs.stdenv.hostPlatform.system} "watt" {
+    package = mkPackageOption wattPackage "watt" {
       pkgsText = "self.packages.\${pkgs.stdenv.hostPlatform.system}";
     };
 
     settings = mkOption {
-      type = submodule {freeformType = format.type;};
+      type = types.submodule {freeformType = format.type;};
       default = {};
-      description = "Configuration for Watt.";
+      description = ''
+        Configuration for Watt.
+        Disjoint with `configFile` option.
+      '';
+    };
+
+    configFile = mkOption {
+      type = types.nullOr (types.either types.package types.str);
+      default = null;
+      description = ''
+        Configuration for Watt.
+        Disjoint with `configFile` option.
+      '';
     };
   };
 
@@ -40,16 +74,12 @@ in {
     environment.systemPackages = [cfg.package];
     services.dbus.packages = [cfg.package];
 
-    # This is necessary for the Watt CLI. The environment variable
-    # passed to the systemd service will take priority in read order.
-    environment.etc."watt.toml".source = cfgFile;
-
     systemd.services.watt = {
       wantedBy = ["multi-user.target"];
       conflicts = map (service: "${service}.service") conflictingServices;
       serviceConfig = {
         WorkingDirectory = "";
-        ExecStart = getExe cfg.package;
+        ExecStart = getExe wrapper;
         Restart = "on-failure";
 
         RuntimeDirectory = "watt";


### PR DESCRIPTION
This pr reworks some of the flake logic, and removes the `inputs: module` defintion to allow non flake users to consume the module