### PR TITLE
config: scope frequency availability to the current CPU

### DIFF
--- a/watt/Cargo.toml
+++ b/watt/Cargo.toml
@@ -23,9 +23,9 @@ jiff.workspace                = true
 log.workspace                 = true
 nix.workspace                 = true
 num_cpus.workspace            = true
+schemars.workspace            = true
 serde.workspace               = true
 serde_json.workspace          = true
-schemars.workspace            = true
 tiny_http                     = { optional = true, workspace = true }
 tokio.workspace               = true
 toml.workspace                = true

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -1621,7 +1621,14 @@ impl Expression {
       },
       CpuIdleSeconds => Number(state.cpu_idle_seconds),
       CpuFrequencyMaximum => Number(try_ok!(state.cpu_frequency_maximum)),
-      CpuFrequencyMinimum => Number(try_ok!(state.cpu_frequency_minimum)),
+      CpuFrequencyMinimum => {
+        Number(try_ok!(match state.context {
+          EvalContext::Cpu(cpu) =>
+            cpu.frequency_mhz_minimum.map(|mhz| mhz as f64),
+          EvalContext::PowerSupply(_) => None,
+          EvalContext::WidestPossible => state.cpu_frequency_minimum,
+        }))
+      },
 
       CpuScalingMaximum => {
         let max = state
@@ -2370,10 +2377,11 @@ mod tests {
   }
 
   #[test]
-  fn frequency_availability_is_scoped_to_the_cpu_being_evaluated() {
+  fn frequency_expressions_are_scoped_to_the_cpu_being_evaluated() {
     let available_cpu = Arc::new(cpu::Cpu {
       number: 0,
       frequency_mhz: Some(1000),
+      frequency_mhz_minimum: Some(702),
       ..cpu::Cpu::default()
     });
     let unavailable_cpu = Arc::new(cpu::Cpu {
@@ -2418,15 +2426,13 @@ mod tests {
       power_supplies:              &power_supplies,
       cpu_log:                     &cpu_log,
     };
-    let guarded_frequency = Expression::IfElse {
-      condition:   Box::new(Expression::FrequencyAvailable),
-      consequence: Box::new(Expression::Number(200.0)),
-      alternative: None,
-    };
-    let cpu_delta = CpusDelta {
-      frequency_mhz_minimum: Some(guarded_frequency),
-      ..CpusDelta::default()
-    };
+    let config = DaemonConfig::load_from(None).expect("load default config");
+    let cpu_delta = &config
+      .rules
+      .iter()
+      .find(|rule| rule.name == "battery-balanced")
+      .expect("default battery-balanced rule")
+      .cpu;
 
     let (deltas, _) = cpu_delta.eval(&state).expect("evaluate CPU deltas");
 
@@ -2434,7 +2440,7 @@ mod tests {
       deltas
         .get(&available_cpu)
         .and_then(|delta| delta.frequency_mhz_minimum),
-      Some(200)
+      Some(702)
     );
     assert_eq!(
       deltas

--- a/watt/config.rs
+++ b/watt/config.rs
@@ -1576,7 +1576,13 @@ impl Expression {
 
         Boolean(find_battery(state.power_supplies, &value).is_some())
       },
-      FrequencyAvailable => Boolean(state.frequency_available),
+      FrequencyAvailable => {
+        Boolean(match state.context {
+          EvalContext::Cpu(cpu) => cpu.frequency_mhz.is_some(),
+          EvalContext::PowerSupply(_) => false,
+          EvalContext::WidestPossible => state.frequency_available,
+        })
+      },
       TurboAvailable => Boolean(state.turbo_available),
 
       CpuUsage => {
@@ -2361,5 +2367,80 @@ mod tests {
     .unwrap();
 
     assert_eq!(result, None);
+  }
+
+  #[test]
+  fn frequency_availability_is_scoped_to_the_cpu_being_evaluated() {
+    let available_cpu = Arc::new(cpu::Cpu {
+      number: 0,
+      frequency_mhz: Some(1000),
+      ..cpu::Cpu::default()
+    });
+    let unavailable_cpu = Arc::new(cpu::Cpu {
+      number: 6,
+      frequency_mhz: None,
+      ..cpu::Cpu::default()
+    });
+    let cpus =
+      HashSet::from([Arc::clone(&available_cpu), Arc::clone(&unavailable_cpu)]);
+
+    let power_supplies = HashSet::new();
+    let uncores = HashSet::new();
+    let disks = HashSet::new();
+    let usb_devices = HashSet::new();
+    let gpus = HashSet::new();
+    let cpu_log = VecDeque::new();
+    let state = EvalState {
+      frequency_available:         true,
+      turbo_available:             false,
+      cpu_usage:                   0.0,
+      cpu_usage_volatility:        None,
+      cpu_temperature:             None,
+      cpu_temperature_volatility:  None,
+      cpu_idle_seconds:            0.0,
+      cpu_frequency_maximum:       None,
+      cpu_frequency_minimum:       None,
+      lid_closed:                  false,
+      virtual_machine:             false,
+      chassis_type:                None,
+      power_supply_charge:         None,
+      power_supply_discharge_rate: None,
+      battery_cycles:              None,
+      battery_health:              None,
+      discharging:                 false,
+      power_profile_preference:    crate::profile::PowerProfile::Balanced,
+      context:                     EvalContext::WidestPossible,
+      cpus:                        &cpus,
+      uncores:                     &uncores,
+      disks:                       &disks,
+      usb_devices:                 &usb_devices,
+      gpus:                        &gpus,
+      power_supplies:              &power_supplies,
+      cpu_log:                     &cpu_log,
+    };
+    let guarded_frequency = Expression::IfElse {
+      condition:   Box::new(Expression::FrequencyAvailable),
+      consequence: Box::new(Expression::Number(200.0)),
+      alternative: None,
+    };
+    let cpu_delta = CpusDelta {
+      frequency_mhz_minimum: Some(guarded_frequency),
+      ..CpusDelta::default()
+    };
+
+    let (deltas, _) = cpu_delta.eval(&state).expect("evaluate CPU deltas");
+
+    assert_eq!(
+      deltas
+        .get(&available_cpu)
+        .and_then(|delta| delta.frequency_mhz_minimum),
+      Some(200)
+    );
+    assert_eq!(
+      deltas
+        .get(&unavailable_cpu)
+        .and_then(|delta| delta.frequency_mhz_minimum),
+      None
+    );
   }
 }

--- a/watt/config.toml
+++ b/watt/config.toml
@@ -127,7 +127,7 @@ priority = 20
 cpu.energy-perf-bias              = { if.is-energy-perf-bias-available = "balance-performance", then = "balance-performance" }
 cpu.energy-performance-preference = { if.is-energy-performance-preference-available = "power", then = "power" }
 cpu.frequency-mhz-maximum         = { if = "?frequency-available", then = 1800 }
-cpu.frequency-mhz-minimum         = { if = "?frequency-available", then = 200 }
+cpu.frequency-mhz-minimum         = { if = "?frequency-available", then = "$cpu-frequency-minimum" }
 cpu.governor                      = { if.is-governor-available = "powersave", then = "powersave" }
 cpu.turbo                         = { if = "?turbo-available", then = false }
 


### PR DESCRIPTION
Evaluate `?frequency-available` against the CPU currently being processed instead of the system-wide availability flag. On heterogeneous systems, one CPU might expose frequency information while another does not because, you guessed it, computers suck. Because computers suck, the previous system-wide check caused guarded frequency rules such as:

```toml
# This is from the default config, which breaks on *some* hardware
cpu.frequency-mhz-minimum = { if = "?frequency-available", then = 200 }
```

to be evaluated for every CPU whenever frequency information was available for any CPU. This could produce an invalid delta for CPUs that do not expose the required frequency interface.

Change-Id: I0106dcde73d80e7dab3d710f403532e86a6a6964